### PR TITLE
Updates for v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,8 @@ It supports:
 -   Managing multiple rooms with multiple cabinets, with a shelf granularity.
 -   Managing different types of materials with different configuration, allowing to specify the structure of each box.
 -   Updating the current inventory, keeping a History of the usage of each material.
-
-### Roadmap
-
--   [x] First bare, working version (0.0.2)
--   [ ] Improving roles and permissions
--   [ ] Improving search
--   [ ] Add alerts
+-   Immediate Alerts when a material is about to finish.
+-   Scheduled Reports when a material is about to finish.
 
 ## :warning: Running Homunculus
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"framer-motion": "^10.16.16",
 		"polished": "^4.3.1",
 		"react": "^18.2.0",
+		"react-barcode-qrcode-scanner": "^0.1.3",
 		"react-dom": "^18.2.0",
 		"react-focus-lock": "2.12.1",
 		"react-icons": "^5.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { AddReportPage } from './pages/report/AddReportPage'
 import { SearchReportsPage } from './pages/report/SearchReportsPage'
 import { SearchTagsPage } from './pages/tag/SearchTagsPage'
 import { UpdateUserPage } from './pages/user/UpdateUserPage'
+import { SearchUsersPage } from './pages/user/SearchUsersPage'
 
 const router = createBrowserRouter([
 	{
@@ -60,7 +61,13 @@ const router = createBrowserRouter([
 				],
 			},
 			{ path: 'tag', element: <SearchTagsPage /> },
-			{ path: 'user', children: [{ index: true, element: <UpdateUserPage /> }] },
+			{
+				path: 'user',
+				children: [
+					{ index: true, element: <UpdateUserPage /> },
+					{ path: 'search', element: <SearchUsersPage /> },
+				],
+			},
 		],
 	},
 	{ path: 'login', element: <LoginPage /> },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { SearchAlertsPage } from './pages/alert/SearchAlertsPage'
 import { AddReportPage } from './pages/report/AddReportPage'
 import { SearchReportsPage } from './pages/report/SearchReportsPage'
 import { SearchTagsPage } from './pages/tag/SearchTagsPage'
+import { UpdateUserPage } from './pages/user/UpdateUserPage'
 
 const router = createBrowserRouter([
 	{
@@ -59,6 +60,7 @@ const router = createBrowserRouter([
 				],
 			},
 			{ path: 'tag', element: <SearchTagsPage /> },
+			{ path: 'user', children: [{ index: true, element: <UpdateUserPage /> }] },
 		],
 	},
 	{ path: 'login', element: <LoginPage /> },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { AlertPage } from './pages/alert/AlertPage'
 import { SearchAlertsPage } from './pages/alert/SearchAlertsPage'
 import { AddReportPage } from './pages/report/AddReportPage'
 import { SearchReportsPage } from './pages/report/SearchReportsPage'
+import { SearchTagsPage } from './pages/tag/SearchTagsPage'
 
 const router = createBrowserRouter([
 	{
@@ -57,6 +58,7 @@ const router = createBrowserRouter([
 					{ path: 'search', element: <SearchReportsPage /> },
 				],
 			},
+			{ path: 'tag', element: <SearchTagsPage /> },
 		],
 	},
 	{ path: 'login', element: <LoginPage /> },

--- a/src/components/box/AddBoxForm.tsx
+++ b/src/components/box/AddBoxForm.tsx
@@ -86,7 +86,7 @@ export const AddBoxForm = ({ defaultMaterial, defaultPosition, onDispatchSuccess
 		defaultValue: 0,
 		validator: input => !!totalInBox && !!input && input >= 1,
 		valueConsumer: value => {
-			if (!!totalInBox && !!lastStep && !!value.value) {
+			if (!!totalInBox && !!lastStep && value.value !== undefined) {
 				dispatchState('quantity', {
 					value: { quantity: value.value * totalInBox, metric: lastStep.type },
 					isValid: value.isValid,

--- a/src/components/box/AddBoxForm.tsx
+++ b/src/components/box/AddBoxForm.tsx
@@ -83,6 +83,7 @@ export const AddBoxForm = ({ defaultMaterial, defaultPosition, onDispatchSuccess
 		valueConsumer: value => dispatchState('material', value),
 	})
 	const quantityControls = useFormControl<number>({
+		defaultValue: 0,
 		validator: input => !!totalInBox && !!input && input >= 1,
 		valueConsumer: value => {
 			if (!!totalInBox && !!lastStep && !!value.value) {
@@ -92,7 +93,6 @@ export const AddBoxForm = ({ defaultMaterial, defaultPosition, onDispatchSuccess
 				})
 			}
 		},
-		defaultValue: 1,
 	})
 
 	const onSubmit = () => {

--- a/src/components/errors/NoBoxesWarning.tsx
+++ b/src/components/errors/NoBoxesWarning.tsx
@@ -1,17 +1,26 @@
 import { Alert, AlertDescription, AlertIcon, AlertTitle, Button, Icon } from '@chakra-ui/react'
 import React from 'react'
 import { Plus } from '@phosphor-icons/react'
+import { useHasPermission } from '../../hooks/permissions'
+import { Permissions } from '../../models/security/Permissions'
 
 export const NoBoxesWarning = ({ onClick }: { onClick: () => void }) => {
+	const hasPermission = useHasPermission()
 	return (
 		<Alert status="warning" flexDirection="column">
 			<AlertIcon />
 			<AlertTitle>There are no boxes on this shelf</AlertTitle>
-			<AlertDescription mt="1em">
-				<Button colorScheme="green" leftIcon={<Icon as={Plus} weight="bold" boxSize={5} />} onClick={onClick}>
-					Add a Box
-				</Button>
-			</AlertDescription>
+			{hasPermission(Permissions.MANAGE_MATERIALS) && (
+				<AlertDescription mt="1em">
+					<Button
+						colorScheme="green"
+						leftIcon={<Icon as={Plus} weight="bold" boxSize={5} />}
+						onClick={onClick}
+					>
+						Add a Box
+					</Button>
+				</AlertDescription>
+			)}
 		</Alert>
 	)
 }

--- a/src/components/forms/AddAlertForm.tsx
+++ b/src/components/forms/AddAlertForm.tsx
@@ -18,7 +18,7 @@ import { FormValues, useForm } from '../../hooks/form'
 import { FormValue } from '../../models/form/FormValue'
 import { User } from '../../models/User'
 import { TextInput } from './controls/TextInput'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { NumberInput } from './controls/NumberInput'
 import { MaterialFilterInput } from './controls/MaterialFilterInput'
 import { NotificationFilter } from '../../models/form/NotificationFilter'
@@ -54,6 +54,7 @@ interface AddAlertFormProps {
 	state?: AlertFormInitialState
 	buttonLabel: string
 	closeButtonAction?: () => void
+	onConfirmAction?: () => void
 }
 
 export const AddAlertForm = ({
@@ -65,6 +66,7 @@ export const AddAlertForm = ({
 	state,
 	buttonLabel,
 	closeButtonAction,
+	onConfirmAction,
 }: AddAlertFormProps) => {
 	const [isFormReset, setIsFormReset] = useState<boolean>(false)
 	const { isOpen, onOpen, onClose } = useDisclosure()
@@ -77,6 +79,13 @@ export const AddAlertForm = ({
 			recipients: { value: state?.recipients, isValid: !!state?.recipients },
 		},
 	})
+
+	const onConfirm = useCallback(() => {
+		onClose()
+		if (!!onConfirmAction) {
+			onConfirmAction()
+		}
+	}, [onClose, onConfirmAction])
 
 	const nameControls = useFormControl<string>({
 		defaultValue: state?.name,
@@ -215,7 +224,7 @@ export const AddAlertForm = ({
 					)}
 				</Flex>
 			</CardFooter>
-			<Modal isOpen={isOpen} onClose={onClose}>
+			<Modal isOpen={isOpen} onClose={onConfirm}>
 				<ModalOverlay />
 				<ModalContent>
 					<ModalBody>
@@ -226,7 +235,7 @@ export const AddAlertForm = ({
 					</ModalBody>
 
 					<ModalFooter>
-						<Button colorScheme="blue" onClick={onClose}>
+						<Button colorScheme="blue" onClick={onConfirm}>
 							Close
 						</Button>
 					</ModalFooter>

--- a/src/components/forms/AddAlertForm.tsx
+++ b/src/components/forms/AddAlertForm.tsx
@@ -188,7 +188,7 @@ export const AddAlertForm = ({
 						controls={descriptionControls}
 					/>
 					<NumberInput
-						label="Threshold"
+						label="Threshold (in boxes)"
 						controls={thresholdControls}
 						invalidLabel="Threshold must be greater than 0."
 					/>

--- a/src/components/forms/AddReportForm.tsx
+++ b/src/components/forms/AddReportForm.tsx
@@ -18,7 +18,7 @@ import { FormValues, useForm } from '../../hooks/form'
 import { FormValue } from '../../models/form/FormValue'
 import { User } from '../../models/User'
 import { TextInput } from './controls/TextInput'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { NumberInput } from './controls/NumberInput'
 import { MaterialFilterInput } from './controls/MaterialFilterInput'
 import { NotificationFilter } from '../../models/form/NotificationFilter'
@@ -58,6 +58,7 @@ interface AddAlertFormProps {
 	state?: ReportFormInitialState
 	buttonLabel: string
 	closeButtonAction?: () => void
+	onConfirmAction?: () => void
 }
 
 export const AddReportForm = ({
@@ -69,6 +70,7 @@ export const AddReportForm = ({
 	state,
 	buttonLabel,
 	closeButtonAction,
+	onConfirmAction,
 }: AddAlertFormProps) => {
 	const [isFormReset, setIsFormReset] = useState<boolean>(false)
 	const { isOpen, onOpen, onClose } = useDisclosure()
@@ -82,6 +84,13 @@ export const AddReportForm = ({
 			recipients: { value: state?.recipients, isValid: !!state?.recipients },
 		},
 	})
+
+	const onConfirm = useCallback(() => {
+		onClose()
+		if (!!onConfirmAction) {
+			onConfirmAction()
+		}
+	}, [onClose, onConfirmAction])
 
 	const nameControls = useFormControl<string>({
 		defaultValue: state?.name,
@@ -239,7 +248,7 @@ export const AddReportForm = ({
 					)}
 				</Flex>
 			</CardFooter>
-			<Modal isOpen={isOpen} onClose={onClose}>
+			<Modal isOpen={isOpen} onClose={onConfirm}>
 				<ModalOverlay />
 				<ModalContent>
 					<ModalBody>
@@ -250,7 +259,7 @@ export const AddReportForm = ({
 					</ModalBody>
 
 					<ModalFooter>
-						<Button colorScheme="blue" onClick={onClose}>
+						<Button colorScheme="blue" onClick={onConfirm}>
 							Close
 						</Button>
 					</ModalFooter>

--- a/src/components/forms/AddReportForm.tsx
+++ b/src/components/forms/AddReportForm.tsx
@@ -207,7 +207,7 @@ export const AddReportForm = ({
 						controls={descriptionControls}
 					/>
 					<NumberInput
-						label="Threshold"
+						label="Threshold (in boxes)"
 						controls={thresholdControls}
 						invalidLabel="Threshold must be greater than 0."
 					/>

--- a/src/components/forms/ChangePasswordForm.tsx
+++ b/src/components/forms/ChangePasswordForm.tsx
@@ -2,6 +2,7 @@ import { Alert, AlertIcon, Container, LayoutProps, SpaceProps } from '@chakra-ui
 import { User } from '../../models/User'
 import { FormValue } from '../../models/form/FormValue'
 import { TextInput } from './controls/TextInput'
+import { useFormControl } from '../../hooks/form-control'
 
 interface ChangePasswordFormProps extends SpaceProps, LayoutProps {
 	user: User
@@ -9,6 +10,7 @@ interface ChangePasswordFormProps extends SpaceProps, LayoutProps {
 	repeatPasswordConsumer: (value: FormValue<string>) => void
 	repeatValidator: (input: string | undefined) => boolean
 	showTokenWarning?: boolean
+	canBeNull: boolean
 }
 
 export const ChangePasswordForm = ({
@@ -17,8 +19,14 @@ export const ChangePasswordForm = ({
 	repeatPasswordConsumer,
 	repeatValidator,
 	showTokenWarning,
+	canBeNull,
 	...style
 }: ChangePasswordFormProps) => {
+	const repeatControls = useFormControl<string>({
+		validator: repeatValidator,
+		valueConsumer: repeatPasswordConsumer,
+	})
+
 	return (
 		<Container {...style}>
 			{!user.passwordHash && (showTokenWarning ?? true) && (
@@ -32,16 +40,18 @@ export const ChangePasswordForm = ({
 				label="New password"
 				placeholder="Insert the new password"
 				isPassword={true}
-				validator={input => !!input && input.length > 6}
-				valueConsumer={passwordConsumer}
+				validator={input => (canBeNull && !input) || (!!input && input.length >= 6)}
+				valueConsumer={data => {
+					repeatControls.resetValue(!data.value || data.value === '')
+					passwordConsumer(data)
+				}}
 				invalidLabel="Your password should contain at least 6 characters."
 			/>
 			<TextInput
 				label="Repeat password"
 				placeholder="Insert again the new password"
 				isPassword={true}
-				validator={repeatValidator}
-				valueConsumer={repeatPasswordConsumer}
+				controls={repeatControls}
 				invalidLabel="The two passwords do not match."
 				marginTop="1em"
 			/>

--- a/src/components/forms/RegisterUserForm.tsx
+++ b/src/components/forms/RegisterUserForm.tsx
@@ -82,7 +82,7 @@ export const RegisterUserForm = ({
 	useEffect(() => {
 		const timeoutId = setTimeout(() => {
 			if (formState.email.isValid && !!formState.email.value) {
-				getUserByEmail(formState.email.value)
+				getUserByEmail({ email: formState.email.value })
 			}
 		}, 1000)
 

--- a/src/components/forms/RegisterUserForm.tsx
+++ b/src/components/forms/RegisterUserForm.tsx
@@ -3,7 +3,7 @@ import { FormValue } from '../../models/form/FormValue'
 import { User } from '../../models/User'
 import { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import { SerializedError } from '@reduxjs/toolkit'
-import { useLazyGetUserByUsernameQuery, useModifyUserMutation } from '../../services/user'
+import { useLazyGetUserByEmailQuery, useLazyGetUserByUsernameQuery, useModifyUserMutation } from '../../services/user'
 import React, { useCallback, useEffect } from 'react'
 import { UserStatus } from '../../models/embed/UserStatus'
 import { Button, LayoutProps, SpaceProps, VStack } from '@chakra-ui/react'
@@ -14,30 +14,60 @@ import { ChangePasswordForm } from './ChangePasswordForm'
 interface RegisterUserFromState extends FormValues {
 	username: FormValue<string>
 	name: FormValue<string>
+	email: FormValue<string>
 	surname: FormValue<string>
 	password: FormValue<string>
 	repeat: FormValue<string>
 }
 
-const initialState: RegisterUserFromState = {
-	username: { value: undefined, isValid: false },
-	name: { value: undefined, isValid: false },
-	surname: { value: undefined, isValid: false },
-	password: { value: undefined, isValid: false },
-	repeat: { value: undefined, isValid: false },
-}
-
 interface RegisterUserFormProps extends LayoutProps, SpaceProps {
 	user: User
+	forceNewUsername: boolean
+	forceNewPassword: boolean
+	canChangeEmail: boolean
+	buttonLabel: string
 	onUpdateError: (error: FetchBaseQueryError | SerializedError) => void
 	onUpdateSuccess: () => void
 }
 
-export const RegisterUserForm = ({ user, onUpdateError, onUpdateSuccess, ...style }: RegisterUserFormProps) => {
-	const [getUserByUsername, { isSuccess: usernameSuccess }] = useLazyGetUserByUsernameQuery()
-	const [modifyUser, { isLoading: updateUserLoading, error: updateUserError, isSuccess: updateUserSuccess }] =
-		useModifyUserMutation()
-	const { formState, dispatchState, isInvalid } = useForm({ initialState })
+function isPasswordValid(password: FormValue<string>, repeat: FormValue<string>, forceNotNull: boolean): boolean {
+	if (!forceNotNull && (!password.value || password.value.length === 0)) {
+		return true
+	} else {
+		return password.isValid && !!password.value && password.value === repeat.value
+	}
+}
+
+export const RegisterUserForm = ({
+	user,
+	onUpdateError,
+	onUpdateSuccess,
+	buttonLabel,
+	forceNewPassword,
+	canChangeEmail,
+	forceNewUsername,
+	...style
+}: RegisterUserFormProps) => {
+	const [getUserByUsername, { isSuccess: usernameSuccess, isLoading: usernameLoading }] =
+		useLazyGetUserByUsernameQuery()
+	const [getUserByEmail, { isSuccess: emailSuccess, isLoading: emailLoading }] = useLazyGetUserByEmailQuery()
+	const [
+		modifyUser,
+		{ isLoading: updateUserLoading, error: updateUserError, isSuccess: updateUserSuccess, reset: updateReset },
+	] = useModifyUserMutation()
+	const { formState, dispatchState, isInvalid } = useForm({
+		initialState: {
+			username: { value: forceNewUsername ? undefined : user.username, isValid: !forceNewUsername },
+			name: { value: user.name, isValid: !!user.name },
+			email: { value: user.email, isValid: true },
+			surname: { value: user.surname, isValid: !!user.surname },
+			password: { value: undefined, isValid: !forceNewPassword },
+			repeat: { value: undefined, isValid: !forceNewPassword },
+		},
+	})
+
+	const usernameIsDuplicate = !usernameLoading && usernameSuccess && formState.username.value !== user.username
+	const emailIsDuplicate = canChangeEmail && !emailLoading && emailSuccess && formState.email.value !== user.email
 
 	useEffect(() => {
 		const timeoutId = setTimeout(() => {
@@ -50,6 +80,16 @@ export const RegisterUserForm = ({ user, onUpdateError, onUpdateSuccess, ...styl
 	}, [formState.username, formState.username.isValid, formState.username.value, getUserByUsername])
 
 	useEffect(() => {
+		const timeoutId = setTimeout(() => {
+			if (formState.email.isValid && !!formState.email.value) {
+				getUserByEmail(formState.email.value)
+			}
+		}, 1000)
+
+		return () => clearTimeout(timeoutId)
+	}, [formState.email.isValid, formState.email.value, getUserByEmail])
+
+	useEffect(() => {
 		if (!!updateUserError) {
 			onUpdateError(updateUserError)
 		}
@@ -57,16 +97,17 @@ export const RegisterUserForm = ({ user, onUpdateError, onUpdateSuccess, ...styl
 
 	useEffect(() => {
 		if (updateUserSuccess) {
+			updateReset()
 			onUpdateSuccess()
 		}
-	}, [onUpdateSuccess, updateUserSuccess])
+	}, [onUpdateSuccess, updateReset, updateUserSuccess])
 
 	const onSubmit = useCallback(
 		(formState: RegisterUserFromState) => {
 			if (!user) {
 				throw new Error('User is not valid')
 			}
-			if (!formState.username.isValid || !formState.username.value || usernameSuccess) {
+			if (!formState.username.isValid || !formState.username.value || usernameIsDuplicate) {
 				throw new Error('Username is not valid')
 			}
 			if (!formState.name.isValid || !formState.name.value) {
@@ -75,40 +116,59 @@ export const RegisterUserForm = ({ user, onUpdateError, onUpdateSuccess, ...styl
 			if (!formState.surname.isValid || !formState.surname.value) {
 				throw new Error('Surname is not valid')
 			}
-			if (
-				!formState.password.isValid ||
-				!formState.password.value ||
-				formState.password.value !== formState.repeat.value
-			) {
+			if (!isPasswordValid(formState.password, formState.repeat, forceNewPassword)) {
 				throw new Error('Password is not valid')
+			}
+			if (canChangeEmail && (!formState.email.isValid || !formState.email.value || emailIsDuplicate)) {
+				throw new Error('Email is not valid')
 			}
 			modifyUser({
 				_id: user._id,
 				username: formState.username.value,
 				status: UserStatus.ACTIVE,
+				email: canChangeEmail ? formState.email.value : undefined,
 				name: formState.name.value,
 				surname: formState.surname.value,
-				passwordHash: formState.password.value,
+				passwordHash:
+					!forceNewPassword && (!formState.password.value || formState.password.value.length === 0)
+						? undefined
+						: formState.password.value,
 			})
 		},
-		[modifyUser, user, usernameSuccess]
+		[canChangeEmail, emailIsDuplicate, forceNewPassword, modifyUser, user, usernameIsDuplicate]
 	)
 
 	return (
 		<VStack {...style}>
-			{usernameSuccess && (
+			{usernameIsDuplicate && (
 				<ErrorAlert info={{ label: 'Error', reason: 'The provided username already exists' }} />
 			)}
+			{emailIsDuplicate && <ErrorAlert info={{ label: 'Error', reason: 'The provided email already exists' }} />}
 			<TextInput
 				label="Username"
-				placeholder="Choose your username"
+				placeholder="Username"
+				defaultValue={forceNewUsername ? undefined : user.username}
 				validator={input => !!input && input.length <= 50}
 				valueConsumer={payload => dispatchState('username', payload)}
 				invalidLabel="The username cannot exceed 50 characters"
 			/>
+			{canChangeEmail && (
+				<TextInput
+					label="Email"
+					placeholder="Email"
+					defaultValue={user.email}
+					validator={input => {
+						const regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+						return !!input && regex.test(input)
+					}}
+					valueConsumer={payload => dispatchState('email', payload)}
+					invalidLabel="Email is not valid"
+				/>
+			)}
 			<TextInput
 				label="Name"
 				placeholder="Name"
+				defaultValue={user.name}
 				validator={input => !!input}
 				valueConsumer={payload => dispatchState('name', payload)}
 				invalidLabel="Invalid name"
@@ -116,19 +176,24 @@ export const RegisterUserForm = ({ user, onUpdateError, onUpdateSuccess, ...styl
 			<TextInput
 				label="Surname"
 				placeholder="Surname"
+				defaultValue={user.surname}
 				validator={input => !!input}
 				valueConsumer={payload => dispatchState('surname', payload)}
 				invalidLabel="Invalid surname"
 			/>
 			<ChangePasswordForm
 				user={user}
+				canBeNull={!forceNewPassword}
 				passwordConsumer={payload => {
 					dispatchState('password', payload)
 				}}
 				repeatPasswordConsumer={payload => {
 					dispatchState('repeat', payload)
 				}}
-				repeatValidator={input => !!input && formState.password.value === input}
+				repeatValidator={input =>
+					(!forceNewPassword && (!formState.password.value || formState.password.value === '')) ||
+					(!!input && formState.password.value === input)
+				}
 				showTokenWarning={false}
 				padding="0px"
 				margin="0px"
@@ -140,10 +205,10 @@ export const RegisterUserForm = ({ user, onUpdateError, onUpdateSuccess, ...styl
 				onClick={() => {
 					onSubmit(formState)
 				}}
-				isDisabled={isInvalid || usernameSuccess || updateUserSuccess}
+				isDisabled={isInvalid || usernameIsDuplicate || emailIsDuplicate || updateUserSuccess}
 				isLoading={updateUserLoading}
 			>
-				Register
+				{buttonLabel}
 			</Button>
 		</VStack>
 	)

--- a/src/components/forms/UpdateQuantityForm.tsx
+++ b/src/components/forms/UpdateQuantityForm.tsx
@@ -36,11 +36,11 @@ export const UpdateQuantityForm = ({ box, boxDefinition, onDispatched }: UpdateQ
 					unitSteps
 						.slice(0, unitSteps.length - 1)
 						.map(_ => 0)
-						.concat([1])
+						.concat([0])
 				),
 				metric: unitSteps[unitSteps.length - 1].type,
 			},
-			isValid: true,
+			isValid: false,
 		},
 	}
 

--- a/src/components/forms/UpdateUserForm.tsx
+++ b/src/components/forms/UpdateUserForm.tsx
@@ -1,0 +1,85 @@
+import { Flex, FormControl, FormErrorMessage, Input, VStack } from '@chakra-ui/react'
+import { User } from '../../models/User'
+import { UserAvatar } from '../ui/UserAvatar'
+import { useCreateProfilePictureMutation, useModifyProfilePictureMutation } from '../../services/profilePicture'
+import React, { useCallback, useState } from 'react'
+import { useModifyUserMutation } from '../../services/user'
+import { ErrorAlert } from '../errors/ErrorAlert'
+import { RegisterUserForm } from './RegisterUserForm'
+import { useIsMobileLayout } from '../../hooks/responsive-size'
+
+interface UpdateUserFormProps {
+	user: User
+}
+
+export const UpdateUserForm = ({ user }: UpdateUserFormProps) => {
+	const isMobile = useIsMobileLayout()
+	const [tokenIsValid, setTokenIsValid] = useState<boolean>(true)
+
+	const [uploadPicture, { isLoading: uploadPictureLoading, error: uploadPictureError }] =
+		useCreateProfilePictureMutation()
+	const [modifyPicture, { isLoading: modifyPictureLoading, error: modifyPictureError }] =
+		useModifyProfilePictureMutation()
+	const [modifyUser, { isLoading: modifyUserLoading, error: modifyUserError }] = useModifyUserMutation()
+
+	const typeIsValid = (type: string) => {
+		return type === 'image/png' || type === 'image/jpeg' || type === 'image/webp'
+	}
+
+	const handleFileChange = useCallback(
+		async (event: React.ChangeEvent<HTMLInputElement>) => {
+			const selectedFile = !!event.target.files ? event.target.files[0] : undefined
+			if (!selectedFile || selectedFile.size > 1024 * 1024 || !typeIsValid(selectedFile.type)) {
+				setTokenIsValid(false)
+			} else if (!!user.profilePicture) {
+				setTokenIsValid(true)
+				modifyPicture({ picture: selectedFile, attachmentId: user.profilePicture })
+			} else {
+				try {
+					const pictureId = await uploadPicture(selectedFile).unwrap()
+					setTokenIsValid(true)
+					modifyUser({
+						...user,
+						profilePicture: pictureId,
+					})
+				} catch (error) {
+					setTokenIsValid(false)
+				}
+			}
+		},
+		[modifyPicture, modifyUser, uploadPicture, user]
+	)
+
+	return (
+		<Flex justifyContent="center" direction={isMobile ? 'column' : 'row'}>
+			<VStack mr="2em" ml="2em">
+				{!!uploadPictureError && (
+					<ErrorAlert
+						info={{ label: 'An error occurred while uploading the picture', reason: uploadPictureError }}
+					/>
+				)}
+				{!!modifyPictureError && (
+					<ErrorAlert
+						info={{ label: 'An error occurred while modifying the picture', reason: modifyPictureError }}
+					/>
+				)}
+				<UserAvatar user={user} showWarning={false} size="xl" />
+				<FormControl isInvalid={!tokenIsValid}>
+					<Input type="file" accept="image/*" onChange={handleFileChange} p={1} />
+					<FormErrorMessage>Only .png, .jpg, and .webp under 1Mb are allowed.</FormErrorMessage>
+				</FormControl>
+			</VStack>
+			<RegisterUserForm
+				ml="1em"
+				width={isMobile ? '90vw' : '50vw'}
+				user={user}
+				forceNewUsername={false}
+				forceNewPassword={false}
+				canChangeEmail={true}
+				buttonLabel="Update"
+				onUpdateError={() => {}}
+				onUpdateSuccess={() => {}}
+			/>
+		</Flex>
+	)
+}

--- a/src/components/forms/controls/BoxDefinitionBuilder.tsx
+++ b/src/components/forms/controls/BoxDefinitionBuilder.tsx
@@ -25,6 +25,7 @@ import { useFormControl } from '../../../hooks/form-control'
 import { FormValue } from '../../../models/form/FormValue'
 import {
 	defaultStep,
+	firstStep,
 	generateDescription,
 	stepsListToUnit,
 	unitIcons,
@@ -33,7 +34,6 @@ import {
 } from '../../../models/embed/UnitStep'
 
 const measures: SelectOption<Metric>[] = [
-	{ value: Metric.ML, name: 'ml', id: 'ml' },
 	{ value: Metric.COMPLEX, name: 'Box', id: 'Box' },
 	{ value: Metric.PIECE, name: 'Units', id: 'Units' },
 ]
@@ -98,7 +98,7 @@ export const BoxDefinitionBuilder = ({
 			})
 		},
 	})
-	const [steps, setSteps] = useState<UnitStep[]>([defaultStep])
+	const [steps, setSteps] = useState<UnitStep[]>([firstStep, defaultStep])
 	const [stepsId, setStepsId] = useState<string>(`${new Date().getTime()}`)
 
 	useEffect(() => {
@@ -179,7 +179,12 @@ export const BoxDefinitionBuilder = ({
 			nameControls.setValue(definition?.name)
 			descriptionControls.setValue(definition?.description)
 			setStepsId(definition?._id ?? `${new Date().getTime()}`)
-			setSteps(unitToStepsList(definition?.boxUnit))
+			if (!!definition?.boxUnit) {
+				setSteps(unitToStepsList(definition?.boxUnit))
+			} else {
+				setSteps([firstStep, defaultStep])
+			}
+
 			setFormValue({
 				value: definition ?? undefined,
 				isValid: !!definition && !!definition._id,
@@ -227,10 +232,8 @@ export const BoxDefinitionBuilder = ({
 				placeholder="Description (optional)"
 				marginBottom="0.6em"
 				controls={descriptionControls}
+				mb="1em"
 			/>
-			<Heading size="md" marginBottom="0.5em">
-				The box contains:
-			</Heading>
 			<Stepper
 				index={steps.length}
 				orientation="vertical"
@@ -245,33 +248,40 @@ export const BoxDefinitionBuilder = ({
 
 						<Box flexShrink="0" marginBottom="1em">
 							<StepTitle>{step.description}</StepTitle>
-							<Flex>
-								<NumberInput
-									label="Quantity"
-									min={0}
-									precision={step.type === Metric.ML ? 2 : 0}
-									defaultValue={step.qty}
-									width="40%"
-									marginRight="0.6em"
-									valueConsumer={value => {
-										if (value.isValid && value.value !== undefined) {
-											updateStepQty(stepIdx, value.value)
-										}
-									}}
-								/>
-								<SelectInput
-									label="Unit of Measure"
-									placeholder="Choose a Unit"
-									values={measures}
-									defaultValue={step.type}
-									width="30%"
-									valueConsumer={value => {
-										if (value.isValid && !!value.value) {
-											updateSteps(stepIdx, value.value.value)
-										}
-									}}
-								/>
-							</Flex>
+							{stepIdx === 0 && step.qty === 1 && step.type === Metric.COMPLEX && (
+								<Heading size="md" mt="0.5em" mb="1em">
+									1 Containing Box
+								</Heading>
+							)}
+							{(stepIdx > 0 || step.qty !== 1 || step.type !== Metric.COMPLEX) && (
+								<Flex>
+									<NumberInput
+										label="Quantity"
+										min={0}
+										precision={step.type === Metric.ML ? 2 : 0}
+										defaultValue={step.qty}
+										width="40%"
+										marginRight="0.6em"
+										valueConsumer={value => {
+											if (value.isValid && value.value !== undefined) {
+												updateStepQty(stepIdx, value.value)
+											}
+										}}
+									/>
+									<SelectInput
+										label="Unit of Measure"
+										placeholder="Choose a Unit"
+										values={measures}
+										defaultValue={step.type}
+										width="30%"
+										valueConsumer={value => {
+											if (value.isValid && !!value.value) {
+												updateSteps(stepIdx, value.value.value)
+											}
+										}}
+									/>
+								</Flex>
+							)}
 						</Box>
 						<StepSeparator />
 					</Step>

--- a/src/components/forms/controls/BoxUnitSelector.tsx
+++ b/src/components/forms/controls/BoxUnitSelector.tsx
@@ -1,14 +1,4 @@
-import {
-	Button,
-	Checkbox,
-	FormControl,
-	FormLabel,
-	HStack,
-	Input,
-	LayoutProps,
-	SpaceProps,
-	Text,
-} from '@chakra-ui/react'
+import { Button, FormControl, FormLabel, HStack, Input, LayoutProps, SpaceProps, Text } from '@chakra-ui/react'
 import { FormValue } from '../../../models/form/FormValue'
 import { BoxUnit } from '../../../models/embed/BoxUnit'
 import React, { useCallback, useMemo, useState } from 'react'
@@ -38,7 +28,7 @@ export const BoxUnitSelector = ({
 		unitSteps
 			.slice(0, unitSteps.length - 1)
 			.map(_ => 0)
-			.concat([1])
+			.concat([0])
 	)
 	const { value, setValue } = useFormControl<BoxUnit>({
 		defaultValue: {
@@ -47,14 +37,13 @@ export const BoxUnitSelector = ({
 				unitSteps
 					.slice(0, unitSteps.length - 1)
 					.map(_ => 0)
-					.concat([1])
+					.concat([0])
 			),
 			metric: unitSteps[unitSteps.length - 1].type,
 		},
 		validator,
 		valueConsumer,
 	})
-	const [isFullBox, setIsFullBox] = useState(false)
 
 	const dispatchNewQuantity = useCallback(
 		(qty: number[]) => {
@@ -86,31 +75,21 @@ export const BoxUnitSelector = ({
 		},
 		[dispatchNewQuantity, unitSteps]
 	)
-
-	const onCheck = (event: React.ChangeEvent<HTMLInputElement>) => {
-		setIsFullBox(event.target.checked)
-		const newState = unitSteps.map(_ => 0)
-		newState[0] = unitSteps[0].qty
-		setStepValues(newState)
-	}
-
 	return (
 		<FormControl {...style}>
 			<FormLabel color={value.isValid ? '' : 'red'}>{label}</FormLabel>
-			<Checkbox onChange={onCheck}>Full box?</Checkbox>
-			{!isFullBox &&
-				unitSteps.map((step, idx) => (
-					<FormControl key={idx} marginTop="0.7em">
-						<FormLabel>
-							{step.icon} {describeStep(step, unitSteps[idx + 1])}
-						</FormLabel>
-						<HStack>
-							<Button onClick={() => onDecrease(idx)}>-</Button>
-							<Input width="5em" type="number" value={stepValues[idx] ?? 0} readOnly />
-							<Button onClick={() => onIncrease(idx)}>+</Button>
-						</HStack>
-					</FormControl>
-				))}
+			{unitSteps.map((step, idx) => (
+				<FormControl key={idx} marginTop="0.7em">
+					<FormLabel>
+						{step.icon} {describeStep(step, unitSteps[idx + 1])}
+					</FormLabel>
+					<HStack>
+						<Button onClick={() => onDecrease(idx)}>-</Button>
+						<Input width="5em" type="number" value={stepValues[idx] ?? 0} readOnly />
+						<Button onClick={() => onIncrease(idx)}>+</Button>
+					</HStack>
+				</FormControl>
+			))}
 			<Text marginTop="0.7em">
 				Total: {computeTotal(unitSteps, stepValues)} {describeStep(unitSteps[unitSteps.length - 1], undefined)}
 			</Text>

--- a/src/components/forms/controls/ColorPicker.tsx
+++ b/src/components/forms/controls/ColorPicker.tsx
@@ -20,34 +20,32 @@ import {
 	SpaceProps,
 	Text,
 } from '@chakra-ui/react'
-import React, { useState } from 'react'
+import React from 'react'
 import { FormValue } from '../../../models/form/FormValue'
 import { getRandomDarkHexColor } from '../../../utils/style-utils'
 import { Repeat } from '@phosphor-icons/react'
+import { FormControls, useFormControl } from '../../../hooks/form-control'
 
 interface ColorPickerProps extends SpaceProps {
 	label: string
 	colors: string[]
 	initialColor?: string
 	valueConsumer?: (value: FormValue<string>) => void
+	controls?: FormControls<string>
 }
 
-export const ColorPicker = ({ label, colors, valueConsumer, initialColor, ...style }: ColorPickerProps) => {
-	const [color, setColor] = useState<FormValue<string>>({
-		value: initialColor ?? getRandomDarkHexColor(),
-		isValid: true,
+export const ColorPicker = ({ label, colors, valueConsumer, initialColor, controls, ...style }: ColorPickerProps) => {
+	const { value, setValue } = useFormControl<string>({
+		validator: input => !!input && RegExp('^#[a-fA-F0-9]{6}$').test(input),
+		valueConsumer,
+		defaultValue: initialColor ?? getRandomDarkHexColor(),
 	})
 
+	const color = controls?.value ?? value
+	const setColor = controls?.setValue ?? setValue
+
 	const handleChange = (event: string) => {
-		const input = event.trim()
-		const newValue = {
-			value: input,
-			isValid: RegExp('^#[a-fA-F0-9]{6}$').test(input),
-		}
-		setColor(newValue)
-		if (!!valueConsumer) {
-			valueConsumer(newValue)
-		}
+		setColor(event.trim())
 	}
 
 	const setRandomColor = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -76,7 +74,7 @@ export const ColorPicker = ({ label, colors, valueConsumer, initialColor, ...sty
 								aria-label="Generate random color"
 								icon={<Icon as={Repeat} weight="bold" boxSize={5} />}
 								onClick={setRandomColor}
-								background="transparent"
+								background="unset"
 								_hover={{ background: 'transparent' }}
 							/>
 						</InputRightAddon>

--- a/src/components/forms/controls/MaterialNameSelector.tsx
+++ b/src/components/forms/controls/MaterialNameSelector.tsx
@@ -51,7 +51,7 @@ export function MaterialNameSelector({
 	const innerSetValue = controls?.setValue ?? setValue
 	const [isTyping, setIsTyping] = useState(false)
 	const { isOpen, onOpen: popoverOpen, onClose: popoverClose } = useDisclosure()
-	const [inputValue, setInputValue] = useState<string | undefined>(controls?.value?.value)
+	const [inputValue, setInputValue] = useState<string>(controls?.value?.value ?? '')
 	const [queryValue, setQueryValue] = useState('')
 	const { data, error, isFetching } = useSearchNamesByNameBrandCodeQuery({ query: queryValue, limit: 5 })
 

--- a/src/components/forms/controls/MaterialSelector.tsx
+++ b/src/components/forms/controls/MaterialSelector.tsx
@@ -1,15 +1,12 @@
 import {
 	Alert,
 	AlertIcon,
-	Box,
-	Divider,
 	Flex,
 	FormControl,
 	FormLabel,
 	Input,
 	InputGroup,
 	InputRightElement,
-	Kbd,
 	LayoutProps,
 	Popover,
 	PopoverBody,
@@ -28,7 +25,7 @@ import { Material } from '../../../models/Material'
 import { useFindMaterialsByFuzzyNameQuery, useGetLastCreatedQuery } from '../../../services/material'
 import { generateSkeletons } from '../../ui/StackedSkeleton'
 import { ErrorAlert } from '../../errors/ErrorAlert'
-import { ElementTag } from '../../models/ElementTag'
+import { MaterialSummary } from '../../models/MaterialSummary'
 
 interface MaterialSelectorProps extends SpaceProps, LayoutProps {
 	label?: string
@@ -153,45 +150,16 @@ export function MaterialSelector({
 								materials.length > 0 &&
 								(!inputValue || inputValue.length > 0) &&
 								materials.map((it, idx) => (
-									<Box key={it._id} width="full">
-										<Flex justifyContent="flex-start" marginLeft="1em" width="full">
-											<Flex
-												_hover={{ cursor: 'pointer' }}
-												onClick={() => {
-													handleSelection(it._id)
-													popoverClose()
-												}}
-												direction="column"
-												width="100%"
-											>
-												<Flex>
-													{idx === 0 && <Kbd marginRight="1em">Tab</Kbd>}
-													<Text>
-														<b>{it.name}</b>, Brand: {it.brand}
-														{!!it.referenceCode && ` - # ${it.referenceCode}`}
-													</Text>
-												</Flex>
-												{!!it.tags && it.tags.length > 0 && (
-													<Flex
-														align="center"
-														justify="start"
-														mt="0.2em"
-														ml={idx === 0 ? '3em' : '0px'}
-													>
-														{it.tags.map(id => (
-															<ElementTag
-																key={id}
-																tagId={id}
-																marginRight="0.4em"
-																compact={!!it.tags && it.tags.length >= 5}
-															/>
-														))}
-													</Flex>
-												)}
-											</Flex>
-										</Flex>
-										<Divider mt="0.5em" ml="1em" width="98%" />
-									</Box>
+									<MaterialSummary
+										key={it._id}
+										material={it}
+										showTabKbd={idx === 0}
+										showDivider={true}
+										onClick={() => {
+											handleSelection(it._id)
+											popoverClose()
+										}}
+									/>
 								))}
 							{!!materials && materials.length === 0 && (
 								<Flex justifyContent="flex-start" marginLeft="1em" width="95%">

--- a/src/components/forms/controls/MaterialSelector.tsx
+++ b/src/components/forms/controls/MaterialSelector.tsx
@@ -53,7 +53,7 @@ export function MaterialSelector({
 	const innerSetValue = controls?.setValue ?? setValue
 	const [isTyping, setIsTyping] = useState(false)
 	const { isOpen, onOpen: popoverOpen, onClose: popoverClose } = useDisclosure()
-	const [inputValue, setInputValue] = useState<string | undefined>(controls?.value?.value?.name)
+	const [inputValue, setInputValue] = useState<string>(controls?.value?.value?.name ?? '')
 	const [queryValue, setQueryValue] = useState('')
 	const { data: defaultValues } = useGetLastCreatedQuery(5)
 	const { data, error, isFetching } = useFindMaterialsByFuzzyNameQuery(

--- a/src/components/forms/controls/RoleSelector.tsx
+++ b/src/components/forms/controls/RoleSelector.tsx
@@ -11,6 +11,7 @@ interface RoleSelectorProps extends LayoutProps, SpaceProps {
 	label: string
 	validator?: (input?: string) => boolean
 	valueConsumer?: (value: FormValue<string>) => void
+	defaultValue?: string
 	invalidLabel?: string
 }
 
@@ -18,9 +19,16 @@ function sortById(arr: Role[]): Role[] {
 	return [...arr].sort((a, b) => a._id.localeCompare(b._id)).reverse()
 }
 
-export const RoleSelector = ({ label, validator, valueConsumer, invalidLabel, ...style }: RoleSelectorProps) => {
+export const RoleSelector = ({
+	label,
+	validator,
+	valueConsumer,
+	defaultValue,
+	invalidLabel,
+	...style
+}: RoleSelectorProps) => {
 	const { data: roles, isLoading, error } = useGetRolesQuery()
-	const { value, setValue } = useFormControl<string>({ validator, valueConsumer })
+	const { value, setValue } = useFormControl<string>({ validator, valueConsumer, defaultValue })
 
 	return (
 		<FormControl {...style}>

--- a/src/components/forms/controls/RoleSelector.tsx
+++ b/src/components/forms/controls/RoleSelector.tsx
@@ -1,0 +1,53 @@
+import { Flex, FormControl, FormLabel, LayoutProps, Radio, RadioGroup, SpaceProps, Stack, Text } from '@chakra-ui/react'
+import { FormValue } from '../../../models/form/FormValue'
+import React from 'react'
+import { useFormControl } from '../../../hooks/form-control'
+import { useGetRolesQuery } from '../../../services/role'
+import { ErrorAlert } from '../../errors/ErrorAlert'
+import { generateSkeletons } from '../../ui/StackedSkeleton'
+import { Role } from '../../../models/embed/Role'
+
+interface RoleSelectorProps extends LayoutProps, SpaceProps {
+	label: string
+	validator?: (input?: string) => boolean
+	valueConsumer?: (value: FormValue<string>) => void
+	invalidLabel?: string
+}
+
+function sortById(arr: Role[]): Role[] {
+	return [...arr].sort((a, b) => a._id.localeCompare(b._id)).reverse()
+}
+
+export const RoleSelector = ({ label, validator, valueConsumer, invalidLabel, ...style }: RoleSelectorProps) => {
+	const { data: roles, isLoading, error } = useGetRolesQuery()
+	const { value, setValue } = useFormControl<string>({ validator, valueConsumer })
+
+	return (
+		<FormControl {...style}>
+			<FormLabel color={value.isValid ? '' : 'red'}>{label}</FormLabel>
+			<Flex direction="column">
+				{!!error && <ErrorAlert info={{ label: 'Cannot load Roles', reason: error }} />}
+				{isLoading && generateSkeletons({ quantity: 3, height: '3em' })}
+				{!!roles && (
+					<RadioGroup onChange={setValue} value={value.value}>
+						<Stack direction="column">
+							{sortById(roles).map(role => (
+								<Radio key={role._id} value={role._id}>
+									<Flex direction="column">
+										<Text as="b">{role.name}</Text>
+										{value.value === role._id && <Text>{role.description}</Text>}
+									</Flex>
+								</Radio>
+							))}
+						</Stack>
+					</RadioGroup>
+				)}
+			</Flex>
+			{!value.isValid && !!invalidLabel && (
+				<Text fontSize="sm" color="red">
+					{invalidLabel}
+				</Text>
+			)}
+		</FormControl>
+	)
+}

--- a/src/components/forms/controls/UsersSelector.tsx
+++ b/src/components/forms/controls/UsersSelector.tsx
@@ -1,5 +1,4 @@
 import {
-	Avatar,
 	Box,
 	Divider,
 	Flex,

--- a/src/components/forms/controls/UsersSelector.tsx
+++ b/src/components/forms/controls/UsersSelector.tsx
@@ -57,7 +57,7 @@ export function UsersSelector({
 	const { isOpen, onOpen: popoverOpen, onClose: popoverClose } = useDisclosure()
 	const [inputValue, setInputValue] = useState<string | undefined>(undefined)
 	const [queryValue, setQueryValue] = useState('')
-	const { data, error, isFetching } = useGetUsersByUsernameEmailNameQuery(queryValue)
+	const { data, error, isFetching } = useGetUsersByUsernameEmailNameQuery({ query: queryValue, onlyActive: true })
 
 	const handleRemoval = useCallback(
 		(userId: string) => {

--- a/src/components/forms/controls/UsersSelector.tsx
+++ b/src/components/forms/controls/UsersSelector.tsx
@@ -55,7 +55,7 @@ export function UsersSelector({
 	const setUsers = controls?.setValue ?? setValue
 	const [isTyping, setIsTyping] = useState(false)
 	const { isOpen, onOpen: popoverOpen, onClose: popoverClose } = useDisclosure()
-	const [inputValue, setInputValue] = useState<string | undefined>(undefined)
+	const [inputValue, setInputValue] = useState<string>('')
 	const [queryValue, setQueryValue] = useState('')
 	const { data, error, isFetching } = useGetUsersByUsernameEmailNameQuery({ query: queryValue, onlyActive: true })
 

--- a/src/components/forms/controls/UsersSelector.tsx
+++ b/src/components/forms/controls/UsersSelector.tsx
@@ -29,6 +29,7 @@ import { ErrorAlert } from '../../errors/ErrorAlert'
 import { User } from '../../../models/User'
 import { useGetUsersByUsernameEmailNameQuery } from '../../../services/user'
 import { X } from '@phosphor-icons/react'
+import { UserAvatar } from '../../ui/UserAvatar'
 
 interface UsersSelectorProps extends SpaceProps, LayoutProps {
 	label?: string
@@ -179,7 +180,7 @@ export function UsersSelector({
 					<Flex key={user._id}>
 						<IconButton
 							colorScheme="red"
-							aria-label="Exclude material"
+							aria-label="Remove user"
 							variant="outline"
 							mr="0.6em"
 							mt="0.2em"
@@ -189,7 +190,7 @@ export function UsersSelector({
 								handleRemoval(user._id)
 							}}
 						/>
-						<Avatar name={user.name ?? user.username} boxSize={10} backgroundColor="teal" />
+						<UserAvatar user={user} showWarning={false} boxSize={10} />
 						<Text fontSize="lg" ml="0.6em" mt="0.3em">
 							{!!user.name || user.surname
 								? `${user.name + ' ' ?? ''}${user.surname ?? ''}`

--- a/src/components/modals/AddTagModal.tsx
+++ b/src/components/modals/AddTagModal.tsx
@@ -1,0 +1,134 @@
+import { FormValue } from '../../models/form/FormValue'
+import { getRandomDarkHexColor } from '../../utils/style-utils'
+import React, { useCallback, useEffect } from 'react'
+import { FetchBaseQueryError } from '@reduxjs/toolkit/query'
+import {
+	Button,
+	Modal,
+	ModalBody,
+	ModalCloseButton,
+	ModalContent,
+	ModalFooter,
+	ModalHeader,
+	ModalOverlay,
+} from '@chakra-ui/react'
+import { ErrorAlert } from '../errors/ErrorAlert'
+import { TextInput } from '../forms/controls/TextInput'
+import { ColorPicker } from '../forms/controls/ColorPicker'
+import { tagColors } from '../../styles/colors'
+import { Tag as MetaTag } from '../../models/embed/Tag'
+import { SerializedError } from '@reduxjs/toolkit'
+import { FormValues, useForm } from '../../hooks/form'
+import { useFormControl } from '../../hooks/form-control'
+
+interface TagFormInitialState {
+	name?: string
+	color?: string
+}
+
+interface AddTagModalProps {
+	isOpen: boolean
+	onClose: () => void
+	action: (tag: Partial<MetaTag>) => void
+	error?: FetchBaseQueryError | SerializedError
+	isSuccessful: boolean
+	initialState?: TagFormInitialState
+	reset: () => void
+	isLoading: boolean
+}
+
+interface AddTagFormData extends FormValues {
+	name: FormValue<string>
+	color: FormValue<string>
+}
+
+export const AddTagModal = ({
+	isOpen,
+	onClose,
+	action,
+	error,
+	isSuccessful,
+	initialState,
+	reset,
+	isLoading,
+}: AddTagModalProps) => {
+	const startingColor = getRandomDarkHexColor()
+	const { formState, dispatchState, isInvalid } = useForm<AddTagFormData>({
+		initialState: {
+			name: { value: initialState?.name, isValid: !!initialState?.name },
+			color: { value: initialState?.color ?? startingColor, isValid: true },
+		},
+	})
+	const nameControls = useFormControl<string>({
+		defaultValue: initialState?.name,
+		validator: input => !!input && input.length <= 50,
+		valueConsumer: data => dispatchState('name', data),
+	})
+	const colorControls = useFormControl<string>({
+		defaultValue: initialState?.color ?? startingColor,
+		valueConsumer: data => dispatchState('color', data),
+	})
+
+	useEffect(() => {
+		if (isSuccessful && !error) {
+			onClose()
+		}
+	}, [onClose, error, isSuccessful])
+
+	const onSubmit = useCallback(
+		(formData: AddTagFormData) => {
+			const name = formData.name.value
+			const color = formData.color.value
+			if (!name) {
+				throw Error('Tag name is not valid')
+			}
+			if (!color) {
+				throw Error('Color is not valid')
+			}
+			action({ name, color })
+			nameControls.resetValue()
+			colorControls.resetValue()
+			dispatchState('reset')
+			reset()
+		},
+		[action, colorControls, dispatchState, nameControls, reset]
+	)
+
+	return (
+		<Modal isOpen={isOpen} onClose={onClose}>
+			<ModalOverlay />
+			<ModalContent>
+				<ModalHeader>Save Tag Information</ModalHeader>
+				<ModalCloseButton />
+
+				<ModalBody>
+					{!!error && <ErrorAlert info={{ label: 'Cannot create the Tag', reason: error }} />}
+					<TextInput
+						label="Name"
+						placeholder="Name (max. 50 characters)"
+						controls={nameControls}
+						invalidLabel="Invalid tag name"
+					/>
+					<ColorPicker marginTop="2em" colors={tagColors} label="Tag color" controls={colorControls} />
+				</ModalBody>
+
+				<ModalFooter>
+					<Button
+						colorScheme="blue"
+						mr={3}
+						isDisabled={isInvalid}
+						isLoading={isLoading}
+						onClick={() => {
+							onSubmit(formState)
+						}}
+					>
+						Create
+					</Button>
+					<Button variant="ghost" onClick={onClose}>
+						Close
+					</Button>
+				</ModalFooter>
+			</ModalContent>
+		</Modal>
+	)
+}

--- a/src/components/modals/ChangePasswordModal.tsx
+++ b/src/components/modals/ChangePasswordModal.tsx
@@ -66,6 +66,7 @@ export const ChangePasswordModal = ({ isOpen, onClose, user }: ChangePasswordMod
 					)}
 					<ChangePasswordForm
 						user={user}
+						canBeNull={false}
 						passwordConsumer={payload => {
 							dispatchState('password', payload)
 						}}

--- a/src/components/modals/ContinueRegistrationModal.tsx
+++ b/src/components/modals/ContinueRegistrationModal.tsx
@@ -39,7 +39,15 @@ export const ContinueRegistrationModal = ({ isOpen, onClose, user }: ContinueReg
 							}}
 						/>
 					)}
-					<RegisterUserForm user={user} onUpdateSuccess={onUpdateSuccess} onUpdateError={onUpdateError} />
+					<RegisterUserForm
+						user={user}
+						onUpdateSuccess={onUpdateSuccess}
+						onUpdateError={onUpdateError}
+						canChangeEmail={false}
+						forceNewPassword={true}
+						forceNewUsername={true}
+						buttonLabel="Update"
+					/>
 				</ModalBody>
 			</ModalContent>
 		</Modal>

--- a/src/components/modals/EditBoxModal.tsx
+++ b/src/components/modals/EditBoxModal.tsx
@@ -119,7 +119,7 @@ export const EditBoxModal = ({ isOpen, onClose, box }: EditBoxModalProps) => {
 									onBoxUpdate(formState)
 								}}
 							>
-								Update Material
+								Update Box
 							</Button>
 							{modifySuccess && (
 								<Icon

--- a/src/components/modals/InviteModal.tsx
+++ b/src/components/modals/InviteModal.tsx
@@ -17,6 +17,7 @@ import { useFormControl } from '../../hooks/form-control'
 import { TextInput } from '../forms/controls/TextInput'
 import { useCallback, useEffect, useState } from 'react'
 import { useInviteUserMutation, useLazyGetUserByEmailQuery } from '../../services/user'
+import { RoleSelector } from '../forms/controls/RoleSelector'
 
 interface InviteModalProps {
 	isOpen: boolean
@@ -30,7 +31,7 @@ export interface InviteUserFromState extends FormValues {
 
 const initialState: InviteUserFromState = {
 	email: { value: undefined, isValid: false },
-	role: { value: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', isValid: true },
+	role: { value: undefined, isValid: false },
 }
 
 export const InviteModal = ({ isOpen, onClose }: InviteModalProps) => {
@@ -49,7 +50,7 @@ export const InviteModal = ({ isOpen, onClose }: InviteModalProps) => {
 
 	useEffect(() => {
 		if (!!formState.email.value && formState.email.isValid) {
-			getUserByEmail(formState.email.value)
+			getUserByEmail({ email: formState.email.value, excludeRegistering: true })
 				.unwrap()
 				.then(
 					() => {
@@ -74,7 +75,7 @@ export const InviteModal = ({ isOpen, onClose }: InviteModalProps) => {
 				inviteUser({
 					email: state.email.value,
 					username: `new-user-${new Date().getTime()}`,
-					roles: [state.role.value],
+					role: state.role.value,
 				})
 			}
 		},
@@ -108,6 +109,13 @@ export const InviteModal = ({ isOpen, onClose }: InviteModalProps) => {
 						placeholder="User email"
 						controls={emailControls}
 						invalidLabel="You must specify a valid email address."
+					/>
+					<RoleSelector
+						label="User role"
+						validator={input => !!input}
+						valueConsumer={payload => dispatchState('role', payload)}
+						invalidLabel="You must specify a valid role"
+						mt="1em"
 					/>
 				</ModalBody>
 

--- a/src/components/models/AlertCard.tsx
+++ b/src/components/models/AlertCard.tsx
@@ -141,6 +141,7 @@ export const AlertCard = ({ alert }: AlertCardProps) => {
 								recipients: users ?? [],
 							}}
 							closeButtonAction={modifyModalClose}
+							onConfirmAction={modifyModalClose}
 						/>
 					</ModalBody>
 				</ModalContent>

--- a/src/components/models/ElementBox.tsx
+++ b/src/components/models/ElementBox.tsx
@@ -1,27 +1,27 @@
 import {
+	Accordion,
+	AccordionButton,
+	AccordionIcon,
+	AccordionItem,
+	AccordionPanel,
+	Box,
+	Button,
 	Card,
 	CardBody,
+	CardFooter,
 	CardHeader,
 	Container,
+	Divider,
 	Flex,
 	Heading,
 	Icon,
+	IconButton,
 	LayoutProps,
 	Skeleton,
 	SpaceProps,
-	Box,
 	Text,
-	CardFooter,
-	Button,
 	useDisclosure,
-	Accordion,
-	AccordionItem,
-	AccordionButton,
-	AccordionIcon,
-	AccordionPanel,
 	VStack,
-	Divider,
-	IconButton,
 } from '@chakra-ui/react'
 import { Box as BoxModel } from '../../models/Box'
 import { useGetMaterialQuery } from '../../services/material'
@@ -36,7 +36,9 @@ import { UsageLogDisplay } from './UsageLogDisplay'
 import { useIsMobileLayout } from '../../hooks/responsive-size'
 import { UpdateBoxFormModal } from '../modals/UpdateBoxFormModal'
 import { EditBoxModal } from '../modals/EditBoxModal'
-import { Package, Trash, UploadSimple, Icon as PhosphorIcon, CalendarX, PencilSimple } from '@phosphor-icons/react'
+import { CalendarX, Icon as PhosphorIcon, Package, PencilSimple, Trash, UploadSimple } from '@phosphor-icons/react'
+import { useHasPermission } from '../../hooks/permissions'
+import { Permissions } from '../../models/security/Permissions'
 
 interface ElementBoxProps extends SpaceProps, LayoutProps {
 	box: BoxModel
@@ -44,6 +46,8 @@ interface ElementBoxProps extends SpaceProps, LayoutProps {
 
 export const ElementBox = ({ box, ...style }: ElementBoxProps) => {
 	const isMobile = useIsMobileLayout()
+	const hasPermission = useHasPermission()
+
 	const [deleteBox, { error: deleteError, isLoading: deleteLoading, isSuccess: deleteSuccess }] =
 		useDeleteBoxMutation()
 	const { onOpen: deleteModalOpen, onClose: deleteModalClose, isOpen: deleteModalIsOpen } = useDisclosure()
@@ -94,12 +98,14 @@ export const ElementBox = ({ box, ...style }: ElementBoxProps) => {
 							{!!daysToExpiration && daysToExpiration <= 0 && (
 								<WarningIcon icon={CalendarX} text={toDayMonthYear(box.expirationDate)} color="red" />
 							)}
-							<IconButton
-								onClick={editModalOpen}
-								aria-label="material settings"
-								icon={<Icon as={PencilSimple} boxSize={6} weight="bold" />}
-								variant="ghost"
-							/>
+							{hasPermission(Permissions.MANAGE_MATERIALS) && (
+								<IconButton
+									onClick={editModalOpen}
+									aria-label="material settings"
+									icon={<Icon as={PencilSimple} boxSize={6} weight="bold" />}
+									variant="ghost"
+								/>
+							)}
 						</Flex>
 					</Flex>
 				</CardHeader>
@@ -153,13 +159,15 @@ export const ElementBox = ({ box, ...style }: ElementBoxProps) => {
 						>
 							Use/Add
 						</Button>
-						<Button
-							colorScheme="red"
-							leftIcon={<Icon as={Trash} weight="bold" boxSize={6} />}
-							onClick={deleteModalOpen}
-						>
-							Delete
-						</Button>
+						{hasPermission(Permissions.MANAGE_MATERIALS) && (
+							<Button
+								colorScheme="red"
+								leftIcon={<Icon as={Trash} weight="bold" boxSize={6} />}
+								onClick={deleteModalOpen}
+							>
+								Delete
+							</Button>
+						)}
 					</Flex>
 				</CardFooter>
 			</Card>

--- a/src/components/models/MaterialCard.tsx
+++ b/src/components/models/MaterialCard.tsx
@@ -23,6 +23,7 @@ import { AddBoxFormModal } from '../modals/AddBoxFormModal'
 import { PencilSimple, Plus, Trash } from '@phosphor-icons/react'
 import { useHasPermission } from '../../hooks/permissions'
 import { Permissions } from '../../models/security/Permissions'
+import { useDeleteBoxesWithMaterialMutation } from '../../services/box'
 
 interface MaterialCardProps {
 	material: Material
@@ -34,6 +35,7 @@ export const MaterialCard = ({ material, isCompact }: MaterialCardProps) => {
 	const hasPermission = useHasPermission()
 
 	const [deleteMaterial, { error: deleteError, isLoading: deleteIsLoading }] = useDeleteMaterialMutation()
+	const [deleteBoxesByMaterial] = useDeleteBoxesWithMaterialMutation()
 	const { onOpen: deleteModalOpen, onClose: deleteModalClose, isOpen: deleteModalIsOpen } = useDisclosure()
 	const { isOpen: detailsOpen, onOpen: openDetails, onClose: detailsClose } = useDisclosure()
 	const { isOpen: addBoxIsOpen, onOpen: onOpenAddBox, onClose: onCloseAddBox } = useDisclosure()
@@ -122,6 +124,7 @@ export const MaterialCard = ({ material, isCompact }: MaterialCardProps) => {
 				error={deleteError}
 				onConfirm={() => {
 					deleteMaterial(material)
+					deleteBoxesByMaterial(material._id)
 				}}
 			/>
 			<DetailedMaterialModal material={material} isOpen={detailsOpen} onClose={detailsClose} />

--- a/src/components/models/MaterialCard.tsx
+++ b/src/components/models/MaterialCard.tsx
@@ -23,7 +23,9 @@ import { AddBoxFormModal } from '../modals/AddBoxFormModal'
 import { PencilSimple, Plus, Trash } from '@phosphor-icons/react'
 import { useHasPermission } from '../../hooks/permissions'
 import { Permissions } from '../../models/security/Permissions'
-import { useDeleteBoxesWithMaterialMutation } from '../../services/box'
+import { useDeleteBoxesWithMaterialMutation, useGetUnitsWithMaterialQuery } from '../../services/box'
+import { useGetBoxDefinitionQuery } from '../../services/boxDefinition'
+import { QuantityCounter } from './QuantityCounter'
 
 interface MaterialCardProps {
 	material: Material
@@ -36,6 +38,9 @@ export const MaterialCard = ({ material, isCompact }: MaterialCardProps) => {
 
 	const [deleteMaterial, { error: deleteError, isLoading: deleteIsLoading }] = useDeleteMaterialMutation()
 	const [deleteBoxesByMaterial] = useDeleteBoxesWithMaterialMutation()
+	const { data: totalInBoxes } = useGetUnitsWithMaterialQuery(material._id)
+	const { data: boxDefinition } = useGetBoxDefinitionQuery(material.boxDefinition)
+
 	const { onOpen: deleteModalOpen, onClose: deleteModalClose, isOpen: deleteModalIsOpen } = useDisclosure()
 	const { isOpen: detailsOpen, onOpen: openDetails, onClose: detailsClose } = useDisclosure()
 	const { isOpen: addBoxIsOpen, onOpen: onOpenAddBox, onClose: onCloseAddBox } = useDisclosure()
@@ -80,6 +85,9 @@ export const MaterialCard = ({ material, isCompact }: MaterialCardProps) => {
 						onClick={!isMobile ? openDetails : undefined}
 					>
 						{!!material.description && <Text>{material.description}</Text>}
+						{!!boxDefinition && !!totalInBoxes && (
+							<QuantityCounter quantity={totalInBoxes} boxDefinition={boxDefinition} mt="0.5em" />
+						)}
 						{!!material.tags && material.tags.length > 0 && (
 							<Flex align="center" justify="start" mt="1em">
 								{material.tags.map(id => (

--- a/src/components/models/MaterialCard.tsx
+++ b/src/components/models/MaterialCard.tsx
@@ -21,6 +21,8 @@ import { useIsMobileLayout } from '../../hooks/responsive-size'
 import { DetailedMaterialModal } from './DetailedMaterialModal'
 import { AddBoxFormModal } from '../modals/AddBoxFormModal'
 import { PencilSimple, Plus, Trash } from '@phosphor-icons/react'
+import { useHasPermission } from '../../hooks/permissions'
+import { Permissions } from '../../models/security/Permissions'
 
 interface MaterialCardProps {
 	material: Material
@@ -29,6 +31,8 @@ interface MaterialCardProps {
 
 export const MaterialCard = ({ material, isCompact }: MaterialCardProps) => {
 	const isMobile = useIsMobileLayout()
+	const hasPermission = useHasPermission()
+
 	const [deleteMaterial, { error: deleteError, isLoading: deleteIsLoading }] = useDeleteMaterialMutation()
 	const { onOpen: deleteModalOpen, onClose: deleteModalClose, isOpen: deleteModalIsOpen } = useDisclosure()
 	const { isOpen: detailsOpen, onOpen: openDetails, onClose: detailsClose } = useDisclosure()
@@ -48,7 +52,7 @@ export const MaterialCard = ({ material, isCompact }: MaterialCardProps) => {
 							<Heading size="md">{material.name}</Heading>
 							{!!material.referenceCode && <Text>RefCode: {material.referenceCode}</Text>}
 						</Box>
-						{isCompact && (
+						{isCompact && hasPermission(Permissions.MANAGE_MATERIALS) && (
 							<IconButton
 								onClick={deleteModalOpen}
 								aria-label="delete material"
@@ -88,7 +92,7 @@ export const MaterialCard = ({ material, isCompact }: MaterialCardProps) => {
 						)}
 					</CardBody>
 				)}
-				{!isCompact && (
+				{!isCompact && hasPermission(Permissions.MANAGE_MATERIALS) && (
 					<CardFooter paddingTop="0px">
 						<Flex width="full" justifyContent="space-between">
 							<Button

--- a/src/components/models/MaterialSummary.tsx
+++ b/src/components/models/MaterialSummary.tsx
@@ -1,0 +1,47 @@
+import { Box, Divider, Flex, Kbd, Text } from '@chakra-ui/react'
+import { ElementTag } from './ElementTag'
+import React from 'react'
+import { Material } from '../../models/Material'
+
+interface MaterialSummaryProps {
+	material: Material
+	onClick?: () => void
+	showTabKbd: boolean
+	showDivider: boolean
+}
+
+export const MaterialSummary = ({ material, onClick, showTabKbd, showDivider }: MaterialSummaryProps) => {
+	return (
+		<Box width="full">
+			<Flex justifyContent="flex-start" marginLeft="1em" width="full">
+				<Flex
+					_hover={!!onClick ? { cursor: 'pointer' } : undefined}
+					onClick={onClick}
+					direction="column"
+					width="100%"
+				>
+					<Flex>
+						{showTabKbd && <Kbd marginRight="1em">Tab</Kbd>}
+						<Text>
+							<b>{material.name}</b>, Brand: {material.brand}
+							{!!material.referenceCode && ` - # ${material.referenceCode}`}
+						</Text>
+					</Flex>
+					{!!material.tags && material.tags.length > 0 && (
+						<Flex align="center" justify="start" mt="0.2em" ml={showTabKbd ? '3em' : '0px'}>
+							{material.tags.map(id => (
+								<ElementTag
+									key={id}
+									tagId={id}
+									marginRight="0.4em"
+									compact={!!material.tags && material.tags.length >= 5}
+								/>
+							))}
+						</Flex>
+					)}
+				</Flex>
+			</Flex>
+			{showDivider && <Divider mt="0.5em" ml="1em" width="98%" />}
+		</Box>
+	)
+}

--- a/src/components/models/RecipientsList.tsx
+++ b/src/components/models/RecipientsList.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Box, Flex, Text } from '@chakra-ui/react'
+import { Box, Flex, Text } from '@chakra-ui/react'
 import { generateSkeletonAvatars } from '../ui/StackedSkeleton'
 import { ErrorAlert } from '../errors/ErrorAlert'
 import React from 'react'

--- a/src/components/models/RecipientsList.tsx
+++ b/src/components/models/RecipientsList.tsx
@@ -4,6 +4,7 @@ import { ErrorAlert } from '../errors/ErrorAlert'
 import React from 'react'
 import { useIsMobileLayout } from '../../hooks/responsive-size'
 import { useGetUsersByIdsQuery } from '../../services/user'
+import { UserAvatar } from '../ui/UserAvatar'
 
 export const RecipientsList = ({ recipients }: { recipients: string[] }) => {
 	const isMobile = useIsMobileLayout()
@@ -22,7 +23,7 @@ export const RecipientsList = ({ recipients }: { recipients: string[] }) => {
 				{!!users &&
 					users.map(user => (
 						<Flex key={user._id}>
-							<Avatar name={user.name ?? user.username} boxSize={10} backgroundColor="teal" />
+							<UserAvatar user={user} showWarning={false} boxSize={10} />
 							{!isMobile && (
 								<Text fontSize="lg" ml="0.6em" mt="0.3em">
 									{!!user.name || user.surname

--- a/src/components/models/ReportCard.tsx
+++ b/src/components/models/ReportCard.tsx
@@ -150,6 +150,7 @@ export const ReportCard = ({ report }: ReportCardProps) => {
 								recipients: users ?? [],
 							}}
 							closeButtonAction={modifyModalClose}
+							onConfirmAction={modifyModalClose}
 						/>
 					</ModalBody>
 				</ModalContent>

--- a/src/components/models/TagCard.tsx
+++ b/src/components/models/TagCard.tsx
@@ -1,0 +1,93 @@
+import {
+	Box,
+	Card,
+	CardBody,
+	CardHeader,
+	Flex,
+	Heading,
+	Icon,
+	IconButton,
+	LayoutProps,
+	Menu,
+	MenuButton,
+	MenuItem,
+	MenuList,
+	SpaceProps,
+	Text,
+	useDisclosure,
+} from '@chakra-ui/react'
+import React from 'react'
+import { Tag as MetaTag } from '../../models/embed/Tag'
+import { DotsThreeVertical, PencilSimple, Trash } from '@phosphor-icons/react'
+import { useDeleteTagMutation, useModifyTagMutation } from '../../services/tag'
+import { ConfirmModal } from '../modals/ConfirmModal'
+import { AddTagModal } from '../modals/AddTagModal'
+
+interface TagCardProps extends SpaceProps, LayoutProps {
+	tag: MetaTag
+}
+
+export const TagCard = ({ tag }: TagCardProps) => {
+	const { isOpen: deleteModalIsOpen, onClose: deleteModalClose, onOpen: deleteModalOpen } = useDisclosure()
+	const { isOpen: modifyModalIsOpen, onClose: modifyModalClose, onOpen: modifyModalOpen } = useDisclosure()
+
+	const [deleteTag, { isLoading: deleteIsLoading, error: deleteError }] = useDeleteTagMutation()
+	const [modifyTag, { isLoading: modifyLoading, error: modifyError, isSuccess: modifySuccess, reset: modifyReset }] =
+		useModifyTagMutation()
+
+	return (
+		<Card>
+			<CardHeader>
+				<Flex justifyContent="space-between" alignItems="center">
+					<Heading size="md">{tag.name}</Heading>
+					<Menu>
+						<MenuButton
+							as={IconButton}
+							aria-label="options"
+							icon={<Icon as={DotsThreeVertical} weight="bold" boxSize={5} />}
+							variant="ghost"
+							mt="0px"
+						/>
+						<MenuList>
+							<MenuItem
+								icon={<Icon as={PencilSimple} weight="bold" boxSize={5} />}
+								onClick={modifyModalOpen}
+							>
+								<Text>Edit</Text>
+							</MenuItem>
+							<MenuItem icon={<Icon as={Trash} weight="bold" boxSize={5} />} onClick={deleteModalOpen}>
+								<Text>Delete</Text>
+							</MenuItem>
+						</MenuList>
+					</Menu>
+				</Flex>
+			</CardHeader>
+			<CardBody pt="0px">
+				<Flex alignItems="center">
+					<Box bg={tag.color} width="20px" height="20px" borderRadius="md" mr={2}></Box>
+					<Text>{tag.color}</Text>
+				</Flex>
+			</CardBody>
+			<ConfirmModal
+				onClose={deleteModalClose}
+				isOpen={deleteModalIsOpen}
+				isLoading={deleteIsLoading}
+				flavour="delete"
+				error={deleteError}
+				onConfirm={() => {
+					deleteTag(tag._id)
+				}}
+			/>
+			<AddTagModal
+				action={updates => modifyTag({ ...tag, ...updates })}
+				isSuccessful={modifySuccess}
+				isLoading={modifyLoading}
+				reset={modifyReset}
+				error={modifyError}
+				isOpen={modifyModalIsOpen}
+				onClose={modifyModalClose}
+				initialState={{ name: tag.name, color: tag.color }}
+			/>
+		</Card>
+	)
+}

--- a/src/components/models/UserCard.tsx
+++ b/src/components/models/UserCard.tsx
@@ -1,0 +1,233 @@
+import {
+	Box,
+	Button,
+	Card,
+	CardBody,
+	CardHeader,
+	Flex,
+	Heading,
+	Icon,
+	IconButton,
+	LayoutProps,
+	Menu,
+	MenuButton,
+	MenuItem,
+	MenuList,
+	Modal,
+	ModalBody,
+	ModalCloseButton,
+	ModalContent,
+	ModalFooter,
+	ModalHeader,
+	ModalOverlay,
+	SpaceProps,
+	Text,
+	useDisclosure,
+} from '@chakra-ui/react'
+import { User } from '../../models/User'
+import { UserAvatar } from '../ui/UserAvatar'
+import {
+	Envelope,
+	Question,
+	UserCircleCheck,
+	UserCircleDashed,
+	UserCircleMinus,
+	User as UserIcon,
+	ChefHat,
+	Toolbox,
+	DotsThreeVertical,
+	PencilSimple,
+	Trash,
+	Prohibit,
+	Power,
+} from '@phosphor-icons/react'
+import { UserStatus } from '../../models/embed/UserStatus'
+import { capitalize } from '../../utils/string-utils'
+import { useGetRoleQuery } from '../../services/role'
+import { Role } from '../../models/embed/Role'
+import React, { useCallback, useState } from 'react'
+import { ErrorAlert } from '../errors/ErrorAlert'
+import { useDeleteUserMutation, useModifyUserRoleMutation, useSetUserStatusMutation } from '../../services/user'
+import { RoleSelector } from '../forms/controls/RoleSelector'
+import { FormValue } from '../../models/form/FormValue'
+import { ConfirmModal } from '../modals/ConfirmModal'
+
+interface UserCardProps extends SpaceProps, LayoutProps {
+	user: User
+}
+
+const iconForStatus = (status?: UserStatus) => {
+	switch (status) {
+		case UserStatus.ACTIVE:
+			return UserCircleCheck
+		case UserStatus.INACTIVE:
+			return UserCircleMinus
+		case UserStatus.REGISTERING:
+			return UserCircleDashed
+		default:
+			return Question
+	}
+}
+
+const iconForRole = (role?: Role) => {
+	switch (role?.name) {
+		case 'Admin':
+			return ChefHat
+		case 'Inventory manager':
+			return Toolbox
+		case 'Basic user':
+			return UserIcon
+		default:
+			return Question
+	}
+}
+
+export const UserCard = ({ user, ...style }: UserCardProps) => {
+	const [roleToUpdate, setRoleToUpdate] = useState<FormValue<string>>({ value: undefined, isValid: false })
+
+	const { data: role } = useGetRoleQuery(user.role ?? '')
+	const [setRole, { error: setRoleError, isLoading: setRoleIsLoading }] = useModifyUserRoleMutation()
+	const [deleteUser, { error: deleteError, isLoading: deleteLoading }] = useDeleteUserMutation()
+	const [setStatus] = useSetUserStatusMutation()
+
+	const { isOpen: statusModalIsOpen, onOpen: statusModalOpen, onClose: statusModalClose } = useDisclosure()
+	const { isOpen: deleteModalIsOpen, onClose: deleteModalClose, onOpen: deleteModalOpen } = useDisclosure()
+
+	const onSetRole = useCallback(() => {
+		if (roleToUpdate.isValid && !!roleToUpdate.value) {
+			setRole({ userId: user._id, roleId: roleToUpdate.value })
+			setRoleToUpdate({ value: undefined, isValid: false })
+			statusModalClose()
+		}
+	}, [roleToUpdate.isValid, roleToUpdate.value, setRole, statusModalClose, user._id])
+
+	return (
+		<Card {...style}>
+			<CardHeader>
+				<Flex width="full" justifyContent="space-between" alignItems="center">
+					<Flex alignItems="center">
+						<UserAvatar user={user} showWarning={false} size="md" mr="0.5em" />
+						<Box>
+							<Heading size="sm">
+								{user.name} {user.surname}
+							</Heading>
+							<Text>@{user.username}</Text>
+						</Box>
+					</Flex>
+					<Menu isLazy={true}>
+						<MenuButton
+							as={IconButton}
+							aria-label="Options"
+							icon={<Icon as={DotsThreeVertical} weight="bold" boxSize={6} />}
+							variant="ghost"
+						/>
+						<MenuList>
+							<MenuItem
+								icon={<Icon as={PencilSimple} weight="bold" boxSize={5} />}
+								onClick={statusModalOpen}
+							>
+								Change role
+							</MenuItem>
+							{user.status === UserStatus.REGISTERING && (
+								<MenuItem
+									icon={<Icon as={Trash} weight="bold" boxSize={5} />}
+									onClick={deleteModalOpen}
+								>
+									Revoke invitation
+								</MenuItem>
+							)}
+							{user.status === UserStatus.ACTIVE && (
+								<MenuItem
+									icon={<Icon as={Prohibit} weight="bold" boxSize={5} />}
+									onClick={() => {
+										setStatus({ userId: user._id, status: UserStatus.INACTIVE })
+									}}
+								>
+									Deactivate User
+								</MenuItem>
+							)}
+							{user.status === UserStatus.INACTIVE && (
+								<MenuItem
+									icon={<Icon as={Power} weight="bold" boxSize={5} />}
+									onClick={() => {
+										setStatus({ userId: user._id, status: UserStatus.ACTIVE })
+									}}
+								>
+									Enable User
+								</MenuItem>
+							)}
+						</MenuList>
+					</Menu>
+				</Flex>
+			</CardHeader>
+			<CardBody pt="0px">
+				<Flex direction="column">
+					<Flex alignItems="center">
+						<Icon as={Envelope} boxSize={5} mr="0.3em" />
+						<Box pb="0.1em">
+							<Text>{user.email}</Text>
+						</Box>
+					</Flex>
+					<Flex alignItems="center">
+						<Icon as={iconForRole(role)} boxSize={5} mr="0.3em" />
+						<Box pb="0.1em">
+							<Text>{role?.name ?? 'Unknown role'}</Text>
+						</Box>
+					</Flex>
+					<Flex alignItems="center">
+						<Icon as={iconForStatus(user.status)} boxSize={5} mr="0.3em" />
+						<Box pb="0.1em">
+							<Text>{capitalize(user.status?.valueOf() ?? 'Unknown')}</Text>
+						</Box>
+					</Flex>
+				</Flex>
+			</CardBody>
+			<ConfirmModal
+				onClose={deleteModalClose}
+				isOpen={deleteModalIsOpen}
+				isLoading={deleteLoading}
+				flavour="delete"
+				error={deleteError}
+				onConfirm={() => {
+					deleteUser(user._id)
+				}}
+			/>
+			<Modal isOpen={statusModalIsOpen} onClose={statusModalClose}>
+				<ModalOverlay />
+				<ModalContent>
+					<ModalHeader>Update {user.name} role</ModalHeader>
+					<ModalCloseButton />
+
+					<ModalBody>
+						{!!setRoleError && (
+							<ErrorAlert info={{ label: 'Cannot set the role for the user', reason: setRoleError }} />
+						)}
+						<RoleSelector
+							label="User role"
+							validator={input => !!input}
+							valueConsumer={setRoleToUpdate}
+							invalidLabel="You must specify a valid role"
+							defaultValue={user.role}
+							mt="1em"
+						/>
+					</ModalBody>
+
+					<ModalFooter>
+						<Button
+							colorScheme="blue"
+							mr={3}
+							isDisabled={!roleToUpdate.isValid}
+							isLoading={setRoleIsLoading}
+							onClick={onSetRole}
+						>
+							Create
+						</Button>
+						<Button variant="ghost" onClick={statusModalClose}>
+							Close
+						</Button>
+					</ModalFooter>
+				</ModalContent>
+			</Modal>
+		</Card>
+	)
+}

--- a/src/components/storage-rooms/CabinetCard.tsx
+++ b/src/components/storage-rooms/CabinetCard.tsx
@@ -1,15 +1,19 @@
 import { Cabinet } from '../../models/embed/storage/Cabinet'
 import {
-	Button,
 	Card,
 	CardBody,
-	CardFooter,
 	CardHeader,
 	Flex,
 	Heading,
 	Icon,
+	IconButton,
 	LayoutProps,
+	Menu,
+	MenuButton,
+	MenuItem,
+	MenuList,
 	SpaceProps,
+	Spacer,
 	Text,
 	useDisclosure,
 } from '@chakra-ui/react'
@@ -18,7 +22,9 @@ import React, { useCallback } from 'react'
 import { useDeleteCabinetMutation, useModifyCabinetMutation } from '../../services/storageRoom'
 import { ConfirmModal } from '../modals/ConfirmModal'
 import { ChangeStorageNameModal } from '../modals/ChangeStorageNameModal'
-import { Lockers, PencilSimple, Trash } from '@phosphor-icons/react'
+import { DotsThreeVertical, Lockers, PencilSimple, Trash } from '@phosphor-icons/react'
+import { Permissions } from '../../models/security/Permissions'
+import { useHasPermission } from '../../hooks/permissions'
 
 interface CabinetCardProps extends SpaceProps, LayoutProps {
 	cabinet: Cabinet
@@ -27,6 +33,7 @@ interface CabinetCardProps extends SpaceProps, LayoutProps {
 
 export const CabinetCard = ({ cabinet, roomId, ...style }: CabinetCardProps) => {
 	const navigate = useNavigate()
+	const hasPermission = useHasPermission()
 
 	const [deleteCabinet, { isLoading: deleteIsLoading, error: deleteError }] = useDeleteCabinetMutation()
 	const [modifyCabinet, { isLoading: modifyIsLoading, error: modifyError, isSuccess: modifySuccess }] =
@@ -54,34 +61,47 @@ export const CabinetCard = ({ cabinet, roomId, ...style }: CabinetCardProps) => 
 	return (
 		<>
 			<Card {...style}>
-				<CardHeader pb="0px" onClick={onCardClick} _hover={{ cursor: 'pointer' }}>
-					<Flex alignItems="center" gap="2">
-						<Icon as={Lockers} boxSize={6} />
-						<Heading size="md">{cabinet.name}</Heading>
+				<CardHeader pb="0px">
+					<Flex width="full" justifyContent="space-between">
+						<Flex direction="column" onClick={onCardClick} _hover={{ cursor: 'pointer' }}>
+							<Flex alignItems="center" gap="2">
+								<Icon as={Lockers} boxSize={6} />
+								<Heading size="md">{cabinet.name}</Heading>
+							</Flex>
+							<Text>{cabinet.description ?? 'No description'}</Text>
+						</Flex>
+						{hasPermission(Permissions.MANAGE_STORAGE) && (
+							<Menu isLazy={true}>
+								<MenuButton
+									as={IconButton}
+									aria-label="Options"
+									icon={<Icon as={DotsThreeVertical} weight="bold" boxSize={6} />}
+									variant="ghost"
+								/>
+								<MenuList>
+									<MenuItem
+										icon={<Icon as={PencilSimple} weight="bold" boxSize={5} />}
+										onClick={onUpdateModalOpen}
+									>
+										Edit cabinet
+									</MenuItem>
+									<MenuItem
+										icon={<Icon as={Trash} weight="bold" boxSize={5} />}
+										onClick={onDeleteModalOpen}
+									>
+										Delete cabinet
+									</MenuItem>
+								</MenuList>
+							</Menu>
+						)}
+						{!hasPermission(Permissions.MANAGE_STORAGE) && (
+							<Spacer onClick={onCardClick} _hover={{ cursor: 'pointer' }} />
+						)}
 					</Flex>
-					<Text>{cabinet.description ?? 'No description'}</Text>
 				</CardHeader>
 				<CardBody pb="0px" onClick={onCardClick} _hover={{ cursor: 'pointer' }}>
 					<Text>{`${cabinet.shelves?.length ?? 0} shel${cabinet.shelves?.length === 1 ? 'f' : 'ves'}`}</Text>
 				</CardBody>
-				<CardFooter>
-					<Flex width="full" justifyContent="space-between">
-						<Button
-							colorScheme="blue"
-							leftIcon={<Icon as={PencilSimple} weight="bold" boxSize={6} />}
-							onClick={onUpdateModalOpen}
-						>
-							Edit
-						</Button>
-						<Button
-							colorScheme="red"
-							leftIcon={<Icon as={Trash} weight="bold" boxSize={6} />}
-							onClick={onDeleteModalOpen}
-						>
-							Delete
-						</Button>
-					</Flex>
-				</CardFooter>
 			</Card>
 			<ConfirmModal
 				onClose={onDeleteModalClose}

--- a/src/components/storage-rooms/ShelfListItem.tsx
+++ b/src/components/storage-rooms/ShelfListItem.tsx
@@ -17,6 +17,8 @@ import { ConfirmModal } from '../modals/ConfirmModal'
 import { Cabinet } from '../../models/embed/storage/Cabinet'
 import { ChangeStorageNameModal } from '../modals/ChangeStorageNameModal'
 import { Dresser, PencilSimple, Trash } from '@phosphor-icons/react'
+import { useHasPermission } from '../../hooks/permissions'
+import { Permissions } from '../../models/security/Permissions'
 
 interface ShelfListItemProps extends StyleProps, SpaceProps {
 	room: StorageRoom
@@ -26,6 +28,7 @@ interface ShelfListItemProps extends StyleProps, SpaceProps {
 }
 
 export const ShelfListItem = ({ room, shelf, cabinet, onClick, ...style }: ShelfListItemProps) => {
+	const hasPermission = useHasPermission()
 	const [deleteShelf, { isLoading: deleteIsLoading, error: deleteError }] = useDeleteShelfMutation()
 	const [modifyShelf, { isLoading: modifyIsLoading, error: modifyError, isSuccess: modifySuccess }] =
 		useModifyShelfMutation()
@@ -49,19 +52,21 @@ export const ShelfListItem = ({ room, shelf, cabinet, onClick, ...style }: Shelf
 
 	return (
 		<Flex {...style}>
-			<Flex direction="column" mr={3} height="100%" gap={2}>
-				<IconButton
-					aria-label="Edit shelf name"
-					icon={<Icon as={PencilSimple} weight="bold" boxSize={5} />}
-					onClick={onUpdateModalOpen}
-				/>
-				<IconButton
-					aria-label="Delete shelf"
-					icon={<Icon as={Trash} weight="bold" boxSize={5} />}
-					colorScheme="red"
-					onClick={onDeleteModalOpen}
-				/>
-			</Flex>
+			{hasPermission(Permissions.MANAGE_STORAGE) && (
+				<Flex direction="column" mr={3} height="100%" gap={2}>
+					<IconButton
+						aria-label="Edit shelf name"
+						icon={<Icon as={PencilSimple} weight="bold" boxSize={5} />}
+						onClick={onUpdateModalOpen}
+					/>
+					<IconButton
+						aria-label="Delete shelf"
+						icon={<Icon as={Trash} weight="bold" boxSize={5} />}
+						colorScheme="red"
+						onClick={onDeleteModalOpen}
+					/>
+				</Flex>
+			)}
 			<Card boxShadow={0} borderWidth="2px" _hover={{ cursor: 'pointer' }} onClick={onClick} {...style}>
 				<CardHeader>
 					<Flex alignItems="center" gap="2">

--- a/src/components/storage-rooms/ShelvesDisplayBig.tsx
+++ b/src/components/storage-rooms/ShelvesDisplayBig.tsx
@@ -12,6 +12,8 @@ import { AddBoxFormModal } from '../modals/AddBoxFormModal'
 import { StorageRoom } from '../../models/StorageRoom'
 import { readableNameFromId } from '../../utils/storage-room-utils'
 import { Plus } from '@phosphor-icons/react'
+import { useHasPermission } from '../../hooks/permissions'
+import { Permissions } from '../../models/security/Permissions'
 
 export interface ShelvesDisplayProps {
 	cabinet: Cabinet
@@ -19,6 +21,8 @@ export interface ShelvesDisplayProps {
 }
 
 export const ShelvesDisplayBig = ({ cabinet, room }: ShelvesDisplayProps) => {
+	const hasPermission = useHasPermission()
+
 	const [selectedShelf, setSelectedShelf] = useState<string | undefined>(undefined)
 	const { data, error, isLoading } = useGetBoxByPositionQuery(selectedShelf ?? '', { skip: !selectedShelf })
 	const { isOpen: addBoxIsOpen, onOpen: onOpenAddBox, onClose: onCloseAddBox } = useDisclosure()
@@ -37,15 +41,18 @@ export const ShelvesDisplayBig = ({ cabinet, room }: ShelvesDisplayProps) => {
 								onClick={() => {
 									setSelectedShelf(`${room._id}|${cabinet.id}|${it.id}`)
 								}}
-								width="90%"
+								width={hasPermission(Permissions.MANAGE_STORAGE) ? '90%' : '94.5%'}
+								ml={hasPermission(Permissions.MANAGE_STORAGE) ? undefined : '0.5em'}
 							/>
 						))}
-						<AddShelfForm key="add-shlf-frm" cabinetId={cabinet.id!} storageRoomId={room._id} />
+						{hasPermission(Permissions.MANAGE_STORAGE) && (
+							<AddShelfForm key="add-shlf-frm" cabinetId={cabinet.id!} storageRoomId={room._id} />
+						)}
 					</VStack>
 				</GridItem>
 				<GridItem colSpan={3}>
 					<VStack width="100%">
-						{!!data && data.length > 0 && (
+						{!!data && data.length > 0 && hasPermission(Permissions.MANAGE_STORAGE) && (
 							<Button
 								width="full"
 								colorScheme="green"

--- a/src/components/storage-rooms/ShelvesDisplayMobile.tsx
+++ b/src/components/storage-rooms/ShelvesDisplayMobile.tsx
@@ -6,11 +6,11 @@ import {
 	DrawerHeader,
 	DrawerOverlay,
 	Flex,
+	Icon,
+	IconButton,
+	Text,
 	useDisclosure,
 	VStack,
-	Text,
-	IconButton,
-	Icon,
 } from '@chakra-ui/react'
 import { ShelfListItem } from './ShelfListItem'
 import { AddShelfForm } from '../forms/AddShelfForm'
@@ -27,8 +27,12 @@ import { AddBoxFormModal } from '../modals/AddBoxFormModal'
 import { readableNameFromId } from '../../utils/storage-room-utils'
 import { NoBoxesWarning } from '../errors/NoBoxesWarning'
 import { Plus, X } from '@phosphor-icons/react'
+import { useHasPermission } from '../../hooks/permissions'
+import { Permissions } from '../../models/security/Permissions'
 
 export const ShelvesDisplayMobile = ({ cabinet, room }: ShelvesDisplayProps) => {
+	const hasPermission = useHasPermission()
+
 	const { isOpen, onOpen, onClose } = useDisclosure()
 	const [selectedShelf, setSelectedShelf] = useState<Shelf | undefined>(undefined)
 	const { isOpen: addBoxIsOpen, onOpen: onOpenAddBox, onClose: onCloseAddBox } = useDisclosure()
@@ -48,10 +52,13 @@ export const ShelvesDisplayMobile = ({ cabinet, room }: ShelvesDisplayProps) => 
 							setSelectedShelf(it)
 							onOpen()
 						}}
-						width="90%"
+						width={hasPermission(Permissions.MANAGE_STORAGE) ? '90%' : '94.5%'}
+						ml={hasPermission(Permissions.MANAGE_STORAGE) ? undefined : '0.5em'}
 					/>
 				))}
-				<AddShelfForm key="add-shlf-frm" cabinetId={cabinet.id!} storageRoomId={room._id} />
+				{hasPermission(Permissions.MANAGE_STORAGE) && (
+					<AddShelfForm key="add-shlf-frm" cabinetId={cabinet.id!} storageRoomId={room._id} />
+				)}
 			</VStack>
 			{!!selectedShelf && (
 				<BoxesDrawer
@@ -91,13 +98,15 @@ interface BoxesDrawerProps {
 }
 
 const BoxesDrawer = ({ shelfName, isOpen, onClose, boxes, boxesLoading, boxesError, onAddClick }: BoxesDrawerProps) => {
+	const hasPermission = useHasPermission()
+
 	return (
 		<Drawer isOpen={isOpen} placement="bottom" onClose={onClose}>
 			<DrawerOverlay />
 			<DrawerContent>
 				<DrawerHeader>
 					<Flex width="full" justifyContent="space-between">
-						{!!boxes && boxes.length > 0 && (
+						{!!boxes && boxes.length > 0 && hasPermission(Permissions.MANAGE_MATERIALS) && (
 							<IconButton
 								onClick={onAddClick}
 								aria-label="add box"

--- a/src/components/storage-rooms/StorageRoomCard.tsx
+++ b/src/components/storage-rooms/StorageRoomCard.tsx
@@ -28,13 +28,15 @@ import {
 } from '../../services/storageRoom'
 import { TextWithDescriptionFormData, TextWithDescriptionModal } from '../forms/TextWithDescriptionModal'
 import { QueryStatus } from '@reduxjs/toolkit/query'
-import { AddIcon, DeleteIcon, EditIcon, HamburgerIcon } from '@chakra-ui/icons'
+import { AddIcon, EditIcon } from '@chakra-ui/icons'
 import { borderDark, borderLight } from '../../styles/theme'
 import { useIsMobileLayout } from '../../hooks/responsive-size'
 import React, { useCallback } from 'react'
 import { ConfirmModal } from '../modals/ConfirmModal'
 import { ChangeStorageNameModal } from '../modals/ChangeStorageNameModal'
-import { Door } from '@phosphor-icons/react'
+import { Door, DotsThreeVertical, Trash } from '@phosphor-icons/react'
+import { useHasPermission } from '../../hooks/permissions'
+import { Permissions } from '../../models/security/Permissions'
 
 interface StorageRoomCardProps extends SpaceProps, LayoutProps {
 	storageRoom: StorageRoom
@@ -42,11 +44,12 @@ interface StorageRoomCardProps extends SpaceProps, LayoutProps {
 
 export const StorageRoomCard = ({ storageRoom, ...style }: StorageRoomCardProps) => {
 	const isMobile = useIsMobileLayout()
+	const hasPermission = useHasPermission()
 	const borderColor = useColorModeValue(borderLight, borderDark)
 	const cabinets = storageRoom.cabinets ?? []
 	const cardWidth: ResponsiveValue<string> = { lg: '17vw', md: '25vw', sm: '40vw' }
 
-	const cabinetCardHeight = isMobile ? '23vh' : '20vh'
+	const cabinetCardHeight = isMobile ? '15vh' : '15vh'
 
 	const [deleteRoom, { isLoading: deleteIsLoading, error: deleteError }] = useDeleteStorageRoomMutation()
 	const [modifyRoom, { isLoading: modifyIsLoading, error: modifyError, isSuccess: modifySuccess }] =
@@ -74,17 +77,27 @@ export const StorageRoomCard = ({ storageRoom, ...style }: StorageRoomCardProps)
 						<Icon as={Door} boxSize={9} />
 						<Heading size="lg"> {storageRoom.name}</Heading>
 					</Flex>
-					<Menu isLazy={true}>
-						<MenuButton as={IconButton} aria-label="Options" icon={<HamburgerIcon />} variant="outline" />
-						<MenuList>
-							<MenuItem icon={<EditIcon />} onClick={onUpdateModalOpen}>
-								Change room name
-							</MenuItem>
-							<MenuItem icon={<DeleteIcon />} onClick={onDeleteModalOpen}>
-								Delete room
-							</MenuItem>
-						</MenuList>
-					</Menu>
+					{hasPermission(Permissions.MANAGE_STORAGE) && (
+						<Menu isLazy={true}>
+							<MenuButton
+								as={IconButton}
+								aria-label="Options"
+								icon={<Icon as={DotsThreeVertical} weight="bold" boxSize={6} />}
+								variant="outline"
+							/>
+							<MenuList>
+								<MenuItem icon={<EditIcon />} onClick={onUpdateModalOpen}>
+									Change room name
+								</MenuItem>
+								<MenuItem
+									icon={<Icon as={Trash} weight="bold" boxSize={5} />}
+									onClick={onDeleteModalOpen}
+								>
+									Delete room
+								</MenuItem>
+							</MenuList>
+						</Menu>
+					)}
 				</Flex>
 				{!!storageRoom.description && <Text>{storageRoom.description}</Text>}
 			</CardHeader>
@@ -99,7 +112,9 @@ export const StorageRoomCard = ({ storageRoom, ...style }: StorageRoomCardProps)
 							width={cardWidth}
 						/>
 					))}
-					<AddCabinetButton storageRoom={storageRoom} width={cardWidth} height={cabinetCardHeight} />
+					{hasPermission(Permissions.MANAGE_STORAGE) && (
+						<AddCabinetButton storageRoom={storageRoom} width={cardWidth} height={cabinetCardHeight} />
+					)}
 				</SimpleGrid>
 			</CardBody>
 			<ConfirmModal
@@ -159,7 +174,7 @@ const AddCabinetButton = ({
 			/>
 			<Card width={width} height={height} _hover={{ cursor: 'pointer' }} onClick={() => onOpen()}>
 				<CardBody>
-					<Center paddingTop="3.2em">
+					<Center paddingTop="1.5em">
 						<AddIcon boxSize={10} />
 					</Center>
 				</CardBody>

--- a/src/components/ui/TopMenu.tsx
+++ b/src/components/ui/TopMenu.tsx
@@ -1,6 +1,5 @@
 import {
 	Avatar,
-	AvatarBadge,
 	Button,
 	Flex,
 	Heading,
@@ -33,6 +32,7 @@ import { pageTitleSelector } from '../../store/ui/ui-slice'
 import { useIsMobileLayout } from '../../hooks/responsive-size'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { ArrowLeft, ExclamationMark, House, SignOut } from '@phosphor-icons/react'
+import { UserAvatar } from './UserAvatar'
 
 export const TopMenu = () => {
 	const isMobile = useIsMobileLayout()
@@ -90,13 +90,7 @@ export const TopMenu = () => {
 							)}
 							<Menu>
 								<MenuButton>
-									<Avatar name={user.name ?? user.username}>
-										{(!user.passwordHash || user.status === UserStatus.REGISTERING) && (
-											<AvatarBadge boxSize="1.25em" bg="red.400">
-												<Icon as={ExclamationMark} weight="bold" boxSize="0.6em" />
-											</AvatarBadge>
-										)}
-									</Avatar>
+									<UserAvatar user={user} showWarning={true} />
 								</MenuButton>
 								<MenuList>
 									{isMobile && (
@@ -130,6 +124,9 @@ export const TopMenu = () => {
 										>
 											Change Password
 										</MenuItem>
+									)}
+									{user.status === UserStatus.ACTIVE && (
+										<MenuItem onClick={() => navigate('/user')}>Modify User Details</MenuItem>
 									)}
 									{user.status === UserStatus.REGISTERING && (
 										<MenuItem

--- a/src/components/ui/UserAvatar.tsx
+++ b/src/components/ui/UserAvatar.tsx
@@ -1,0 +1,29 @@
+import { User } from '../../models/User'
+import { Avatar, AvatarBadge, Icon, ResponsiveValue } from '@chakra-ui/react'
+import { UserStatus } from '../../models/embed/UserStatus'
+import { ExclamationMark } from '@phosphor-icons/react'
+import React from 'react'
+import { useGetProfilePictureQuery } from '../../services/profilePicture'
+
+interface UserAvatarProps {
+	user: User
+	showWarning: boolean
+	size?: ResponsiveValue<string>
+}
+
+export const UserAvatar = ({ user, showWarning, size }: UserAvatarProps) => {
+	const { data: token } = useGetProfilePictureQuery(user.profilePicture ?? '', { skip: !user.profilePicture })
+	return (
+		<Avatar
+			size={size}
+			name={user.name ?? user.username}
+			src={!!token ? `data:${token.type.toLowerCase()};base64,${token.content}` : undefined}
+		>
+			{(!user.passwordHash || user.status === UserStatus.REGISTERING) && showWarning && (
+				<AvatarBadge boxSize="1.25em" bg="red.400">
+					<Icon as={ExclamationMark} weight="bold" boxSize="0.6em" />
+				</AvatarBadge>
+			)}
+		</Avatar>
+	)
+}

--- a/src/components/ui/UserAvatar.tsx
+++ b/src/components/ui/UserAvatar.tsx
@@ -1,23 +1,24 @@
 import { User } from '../../models/User'
-import { Avatar, AvatarBadge, Icon, ResponsiveValue } from '@chakra-ui/react'
+import { Avatar, AvatarBadge, Icon, ResponsiveValue, SpaceProps } from '@chakra-ui/react'
 import { UserStatus } from '../../models/embed/UserStatus'
 import { ExclamationMark } from '@phosphor-icons/react'
 import React from 'react'
 import { useGetProfilePictureQuery } from '../../services/profilePicture'
 
-interface UserAvatarProps {
+interface UserAvatarProps extends SpaceProps {
 	user: User
 	showWarning: boolean
 	size?: ResponsiveValue<string>
 }
 
-export const UserAvatar = ({ user, showWarning, size }: UserAvatarProps) => {
+export const UserAvatar = ({ user, showWarning, size, ...style }: UserAvatarProps) => {
 	const { data: token } = useGetProfilePictureQuery(user.profilePicture ?? '', { skip: !user.profilePicture })
 	return (
 		<Avatar
 			size={size}
 			name={user.name ?? user.username}
 			src={!!token ? `data:${token.type.toLowerCase()};base64,${token.content}` : undefined}
+			{...style}
 		>
 			{(!user.passwordHash || user.status === UserStatus.REGISTERING) && showWarning && (
 				<AvatarBadge boxSize="1.25em" bg="red.400">

--- a/src/components/ui/UserAvatar.tsx
+++ b/src/components/ui/UserAvatar.tsx
@@ -1,11 +1,11 @@
 import { User } from '../../models/User'
-import { Avatar, AvatarBadge, Icon, ResponsiveValue, SpaceProps } from '@chakra-ui/react'
+import { Avatar, AvatarBadge, AvatarProps, Icon, ResponsiveValue, SpaceProps } from '@chakra-ui/react'
 import { UserStatus } from '../../models/embed/UserStatus'
 import { ExclamationMark } from '@phosphor-icons/react'
 import React from 'react'
 import { useGetProfilePictureQuery } from '../../services/profilePicture'
 
-interface UserAvatarProps extends SpaceProps {
+interface UserAvatarProps extends SpaceProps, AvatarProps {
 	user: User
 	showWarning: boolean
 	size?: ResponsiveValue<string>

--- a/src/hooks/form-control.ts
+++ b/src/hooks/form-control.ts
@@ -8,7 +8,7 @@ export interface FormControls<T> {
 	setValue: (value: T | undefined | FormValueDispatcher<T>) => void
 	validator?: (value: T | undefined) => boolean
 	valueConsumer?: (value: FormValue<T>) => void
-	resetValue: () => void
+	resetValue: (isValid?: boolean) => void
 }
 
 interface FormControlParams<T> {
@@ -47,16 +47,19 @@ export function useFormControl<T>({ defaultValue, validator, valueConsumer }: Fo
 		[validator, valueConsumer]
 	)
 
-	const resetValue = useCallback(() => {
-		const newValue = {
-			value: defaultValue,
-			isValid: true,
-		}
-		setFormValue(newValue)
-		if (!!valueConsumer) {
-			valueConsumer(newValue)
-		}
-	}, [defaultValue, valueConsumer])
+	const resetValue = useCallback(
+		(isValid?: boolean) => {
+			const newValue = {
+				value: defaultValue,
+				isValid: isValid ?? true,
+			}
+			setFormValue(newValue)
+			if (!!valueConsumer) {
+				valueConsumer(newValue)
+			}
+		},
+		[defaultValue, valueConsumer]
+	)
 
 	return { value: formValue, setValue, validator, valueConsumer, resetValue }
 }

--- a/src/hooks/permissions.ts
+++ b/src/hooks/permissions.ts
@@ -1,0 +1,19 @@
+import { useGetCurrentUserQuery } from '../services/user'
+import { useGetRoleQuery } from '../services/role'
+import { useCallback } from 'react'
+import { Permissions } from '../models/security/Permissions'
+
+export function useHasPermission(): (permission: Permissions) => boolean {
+	const { data: currentUser } = useGetCurrentUserQuery()
+	const { data: currentRole } = useGetRoleQuery(currentUser?.role ?? '', { skip: !currentUser?.role })
+
+	return useCallback(
+		(permission: Permissions) => {
+			return (
+				(currentRole?.permissions?.includes(Permissions.ADMIN) ?? false) ||
+				(currentRole?.permissions?.includes(permission) ?? false)
+			)
+		},
+		[currentRole?.permissions]
+	)
+}

--- a/src/models/Attachment.ts
+++ b/src/models/Attachment.ts
@@ -1,0 +1,3 @@
+export interface Attachment {
+	_id: string
+}

--- a/src/models/ProfilePicture.ts
+++ b/src/models/ProfilePicture.ts
@@ -1,0 +1,6 @@
+import { Attachment } from './Attachment'
+
+export interface ProfilePicture extends Attachment {
+	content: string
+	type: string
+}

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -10,5 +10,6 @@ export interface User {
 	surname?: string
 	roles: string[]
 	email?: string
+	profilePicture?: string
 	authenticationTokens: { [key: string]: AuthToken }
 }

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -8,7 +8,7 @@ export interface User {
 	status?: UserStatus
 	name?: string
 	surname?: string
-	roles: string[]
+	role?: string
 	email?: string
 	profilePicture?: string
 	authenticationTokens: { [key: string]: AuthToken }

--- a/src/models/embed/Role.ts
+++ b/src/models/embed/Role.ts
@@ -1,0 +1,8 @@
+import { Permissions } from '../security/Permissions'
+
+export interface Role {
+	_id: string
+	name: string
+	description: string
+	permissions: Permissions[]
+}

--- a/src/models/embed/UnitStep.tsx
+++ b/src/models/embed/UnitStep.tsx
@@ -49,9 +49,16 @@ export const generateLabel = (type: Metric) => {
 
 export const defaultStep: UnitStep = {
 	qty: 0,
-	type: Metric.ML,
-	description: generateDescription(0, Metric.ML),
-	icon: unitIcons[Metric.ML],
+	type: Metric.PIECE,
+	description: generateDescription(0, Metric.PIECE),
+	icon: unitIcons[Metric.PIECE],
+}
+
+export const firstStep: UnitStep = {
+	qty: 1,
+	type: Metric.COMPLEX,
+	description: generateDescription(1, Metric.COMPLEX),
+	icon: unitIcons[Metric.COMPLEX],
 }
 
 export function unitToStepsList(unit: BoxUnit | undefined, steps: UnitStep[] = []): UnitStep[] {

--- a/src/models/embed/UserStatus.ts
+++ b/src/models/embed/UserStatus.ts
@@ -1,4 +1,5 @@
 export enum UserStatus {
 	ACTIVE = 'ACTIVE',
+	INACTIVE = 'INACTIVE',
 	REGISTERING = 'REGISTERING',
 }

--- a/src/models/security/Permissions.ts
+++ b/src/models/security/Permissions.ts
@@ -1,4 +1,4 @@
-export enum PERMISSIONS {
+export enum Permissions {
 	ADMIN = 'ADMIN',
 	MANAGE_STORAGE = 'MANAGE_STORAGE',
 	MANAGE_MATERIALS = 'MANAGE_MATERIALS',

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -2,7 +2,6 @@ import {
 	Alert,
 	AlertIcon,
 	Button,
-	Center,
 	Image,
 	Heading,
 	Input,

--- a/src/pages/PasswordResetPage.tsx
+++ b/src/pages/PasswordResetPage.tsx
@@ -126,6 +126,7 @@ export const PasswordResetPage = () => {
 				<VStack>
 					<ChangePasswordForm
 						user={user}
+						canBeNull={false}
 						passwordConsumer={payload => {
 							dispatchState('password', payload)
 						}}

--- a/src/pages/PasswordResetPage.tsx
+++ b/src/pages/PasswordResetPage.tsx
@@ -48,11 +48,11 @@ export const PasswordResetPage = () => {
 	}, [email, login, newToken])
 
 	useEffect(() => {
-		if (!!jwtResponse) {
+		if (!!jwtResponse && !!email) {
 			dispatch(setAuthenticationState(jwtResponse))
 			localStorage.setItem(localStorageJwtKey, jwtResponse.jwt)
 			localStorage.setItem(localStorageRefreshJwtKey, jwtResponse.refreshJwt)
-			getUserByEmail(email!)
+			getUserByEmail({ email })
 		}
 	}, [dispatch, email, getUserByEmail, jwtResponse])
 

--- a/src/pages/RegisterUserPage.tsx
+++ b/src/pages/RegisterUserPage.tsx
@@ -41,11 +41,11 @@ export const RegisterUserPage = () => {
 	}, [email, login, tmpToken])
 
 	useEffect(() => {
-		if (!!jwtResponse) {
+		if (!!jwtResponse && !!email) {
 			dispatch(setAuthenticationState(jwtResponse))
 			localStorage.setItem(localStorageJwtKey, jwtResponse.jwt)
 			localStorage.setItem(localStorageRefreshJwtKey, jwtResponse.refreshJwt)
-			getUserByEmail(email!)
+			getUserByEmail({ email })
 		}
 	}, [dispatch, email, getUserByEmail, jwtResponse])
 

--- a/src/pages/RegisterUserPage.tsx
+++ b/src/pages/RegisterUserPage.tsx
@@ -113,6 +113,10 @@ export const RegisterUserPage = () => {
 						user={user}
 						onUpdateSuccess={onUpdateSuccess}
 						onUpdateError={onUpdateError}
+						forceNewPassword={true}
+						forceNewUsername={true}
+						canChangeEmail={false}
+						buttonLabel="Register"
 						pl="10vw"
 						pr="10vw"
 						mb="1em"

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -1,7 +1,0 @@
-export const UserPage = () =>
-{
-	return <>
-		<h1>User</h1>
-	</>
-}
-

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -95,9 +95,9 @@ export const HomePage = () => {
 					<MainMenuItem
 						title="Lab Management"
 						elements={Object.fromEntries(
-							([] as string[][]).concat(
-								hasPermission(Permissions.MANAGE_METADATA) ? [['Manage Tags', '/tag']] : []
-							)
+							([] as string[][])
+								.concat(hasPermission(Permissions.MANAGE_METADATA) ? [['Manage Tags', '/tag']] : [])
+								.concat(hasPermission(Permissions.ADMIN) ? [['Manage Users', '/user/search']] : [])
 						)}
 						width={menuItemWidth}
 						showLastDivider={false}

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,18 +1,16 @@
 import { Flex } from '@chakra-ui/react'
-import { useAppDispatch, useAppSelector } from '../../hooks/redux'
+import { useAppDispatch } from '../../hooks/redux'
 import { resetPageTitle } from '../../store/ui/ui-slice'
 import { useEffect } from 'react'
 import { MainMenuItem } from '../../components/ui/MainMenuItem'
 import { useIsMobileLayout } from '../../hooks/responsive-size'
-import { jwtSelector } from '../../store/auth/auth-slice'
-import { useGetPermissionsQuery } from '../../services/user'
-import { PERMISSIONS } from '../../models/security/Permissions'
+import { Permissions } from '../../models/security/Permissions'
+import { useHasPermission } from '../../hooks/permissions'
 
 export const HomePage = () => {
 	const isMobile = useIsMobileLayout()
 	const dispatch = useAppDispatch()
-	const jwt = useAppSelector(jwtSelector)
-	const { data: permissions } = useGetPermissionsQuery(undefined, { skip: !jwt })
+	const hasPermission = useHasPermission()
 
 	useEffect(() => {
 		dispatch(resetPageTitle())
@@ -35,26 +33,30 @@ export const HomePage = () => {
 				<MainMenuItem
 					title="Storage"
 					elements={{ 'Browse rooms': '/storage' }}
-					showLastDivider={true}
+					showLastDivider={hasPermission(Permissions.MANAGE_MATERIALS)}
 					width={menuItemWidth}
 				/>
 				<MainMenuItem
-					title="Material"
-					elements={{
-						'Add a new Material': '/material',
-						'Search Materials': '/material/search',
-					}}
+					title="Catalog"
+					elements={Object.fromEntries(
+						([] as string[][])
+							.concat(
+								hasPermission(Permissions.MANAGE_MATERIALS) ? [['Add a new Material', '/material']] : []
+							)
+							.concat([['Search Materials', '/material/search']])
+					)}
 					showLastDivider={false}
 					width={menuItemWidth}
 				/>
 				<MainMenuItem
-					title="Box"
-					elements={{
-						'Add a new Box': '/box',
-						'Search Boxes': '/box/search',
-					}}
-					width={menuItemWidth}
+					title="Inventory"
+					elements={Object.fromEntries(
+						([] as string[][])
+							.concat(hasPermission(Permissions.MANAGE_MATERIALS) ? [['Add a new Box', '/box']] : [])
+							.concat([['Search Boxes', '/box/search']])
+					)}
 					showLastDivider={false}
+					width={menuItemWidth}
 				/>
 			</Flex>
 			<Flex
@@ -67,48 +69,40 @@ export const HomePage = () => {
 				pr={isMobile ? '1em' : undefined}
 				mt={'1em'}
 			>
-				{!!permissions &&
-					(permissions.includes(PERMISSIONS.ADMIN) ||
-						permissions.includes(PERMISSIONS.MANAGE_NOTIFICATIONS)) && (
-						<MainMenuItem
-							title="Alerts"
-							elements={{
-								'Add a new Alert': '/alert',
-								'Search alerts': '/alert/search',
-							}}
-							width={menuItemWidth}
-							showLastDivider={false}
-						/>
-					)}
-				{!!permissions &&
-					(permissions.includes(PERMISSIONS.ADMIN) ||
-						permissions.includes(PERMISSIONS.MANAGE_NOTIFICATIONS)) && (
-						<MainMenuItem
-							title="Reports"
-							elements={{
-								'Add a new Report': '/report',
-								'Search reports': '/report/search',
-							}}
-							width={menuItemWidth}
-							showLastDivider={false}
-						/>
-					)}
-				{!!permissions &&
-					(permissions.includes(PERMISSIONS.ADMIN) || permissions.includes(PERMISSIONS.MANAGE_METADATA)) && (
-						<MainMenuItem
-							title="Lab Management"
-							elements={Object.fromEntries(
-								([] as string[][]).concat(
-									permissions.includes(PERMISSIONS.ADMIN) ||
-										permissions.includes(PERMISSIONS.MANAGE_METADATA)
-										? [['Manage Tags', '/tag']]
-										: []
-								)
-							)}
-							width={menuItemWidth}
-							showLastDivider={false}
-						/>
-					)}
+				{hasPermission(Permissions.MANAGE_NOTIFICATIONS) && (
+					<MainMenuItem
+						title="Alerts"
+						elements={{
+							'Add a new Alert': '/alert',
+							'Search alerts': '/alert/search',
+						}}
+						width={menuItemWidth}
+						showLastDivider={false}
+					/>
+				)}
+				{hasPermission(Permissions.MANAGE_NOTIFICATIONS) && (
+					<MainMenuItem
+						title="Reports"
+						elements={{
+							'Add a new Report': '/report',
+							'Search reports': '/report/search',
+						}}
+						width={menuItemWidth}
+						showLastDivider={false}
+					/>
+				)}
+				{hasPermission(Permissions.MANAGE_METADATA) && (
+					<MainMenuItem
+						title="Lab Management"
+						elements={Object.fromEntries(
+							([] as string[][]).concat(
+								hasPermission(Permissions.MANAGE_METADATA) ? [['Manage Tags', '/tag']] : []
+							)
+						)}
+						width={menuItemWidth}
+						showLastDivider={false}
+					/>
+				)}
 			</Flex>
 		</Flex>
 	)

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -20,6 +20,7 @@ export const HomePage = () => {
 
 	const menuItemWidth = isMobile ? '100%' : '31vw'
 
+	// @ts-ignore
 	return (
 		<Flex width="full" justifyContent="center" alignItems="top" direction="column" padding="0px" margin="0px">
 			<Flex
@@ -88,6 +89,22 @@ export const HomePage = () => {
 								'Add a new Report': '/report',
 								'Search reports': '/report/search',
 							}}
+							width={menuItemWidth}
+							showLastDivider={false}
+						/>
+					)}
+				{!!permissions &&
+					(permissions.includes(PERMISSIONS.ADMIN) || permissions.includes(PERMISSIONS.MANAGE_METADATA)) && (
+						<MainMenuItem
+							title="Lab Management"
+							elements={Object.fromEntries(
+								([] as string[][]).concat(
+									permissions.includes(PERMISSIONS.ADMIN) ||
+										permissions.includes(PERMISSIONS.MANAGE_METADATA)
+										? [['Manage Tags', '/tag']]
+										: []
+								)
+							)}
 							width={menuItemWidth}
 							showLastDivider={false}
 						/>

--- a/src/pages/storage/ManageStoragePage.tsx
+++ b/src/pages/storage/ManageStoragePage.tsx
@@ -9,12 +9,16 @@ import { ErrorAlert } from '../../components/errors/ErrorAlert'
 import { useAppDispatch } from '../../hooks/redux'
 import { setPageTitle } from '../../store/ui/ui-slice'
 import { useEffect } from 'react'
+import { useHasPermission } from '../../hooks/permissions'
+import { Permissions } from '../../models/security/Permissions'
 
 export const ManageStoragePage = () => {
 	const dispatch = useAppDispatch()
 	useEffect(() => {
 		dispatch(setPageTitle('Storage Rooms'))
 	}, [dispatch])
+
+	const hasPermission = useHasPermission()
 	const { data, error, isFetching } = useGetStorageRoomsQuery()
 	return (
 		<VStack>
@@ -26,7 +30,7 @@ export const ManageStoragePage = () => {
 				/>
 			)}
 			{!!data && data.map(it => <StorageRoomCard key={it._id} storageRoom={it} width="90vw" />)}
-			<AddStorageButton key="add-storage-btn" />
+			{hasPermission(Permissions.MANAGE_STORAGE) && <AddStorageButton key="add-storage-btn" />}
 		</VStack>
 	)
 }

--- a/src/pages/tag/SearchTagsPage.tsx
+++ b/src/pages/tag/SearchTagsPage.tsx
@@ -1,0 +1,125 @@
+import { useAppDispatch } from '../../hooks/redux'
+import React, { useCallback, useEffect, useState } from 'react'
+import { setPageTitle } from '../../store/ui/ui-slice'
+import { useIsMobileLayout } from '../../hooks/responsive-size'
+import {
+	Alert,
+	AlertIcon,
+	Center,
+	Input,
+	InputGroup,
+	InputLeftAddon,
+	InputRightElement,
+	SimpleGrid,
+	Spinner,
+	useBreakpointValue,
+	VStack,
+} from '@chakra-ui/react'
+import { SearchIcon } from '@chakra-ui/icons'
+import { ErrorAlert } from '../../components/errors/ErrorAlert'
+import { StackedSkeleton } from '../../components/ui/StackedSkeleton'
+import { useGetTagsByIdsQuery, useSearchTagIdsByNameQuery } from '../../services/tag'
+import { TagCard } from '../../components/models/TagCard'
+import { Size } from '../../components/forms/controls/TagInput'
+
+const cardsForSize: Record<Size, { cards: number }> = {
+	xl: { cards: 5 },
+	lg: { cards: 4 },
+	md: { cards: 3 },
+	sm: { cards: 1 },
+	base: { cards: 1 },
+}
+
+export const SearchTagsPage = () => {
+	const isMobile = useIsMobileLayout()
+	const dispatch = useAppDispatch()
+	useEffect(() => {
+		dispatch(setPageTitle('Search Tags'))
+	}, [dispatch])
+
+	const size = useBreakpointValue<{ cards: number }>(cardsForSize, {
+		fallback: 'md',
+	})
+	const sideMargin = isMobile ? '0.5em' : '2em'
+
+	const [isTyping, setIsTyping] = useState<boolean>(false)
+	const [rawQuery, setRawQuery] = useState<string>('')
+	const [query, setQuery] = useState<string>('')
+
+	const { data: tagIds, error: idsError, isLoading: idsLoading } = useSearchTagIdsByNameQuery(query)
+
+	const {
+		data: tags,
+		error: tagsError,
+		isLoading: tagsLoading,
+	} = useGetTagsByIdsQuery(tagIds ?? [], {
+		skip: !tagIds || tagIds.length === 0,
+	})
+
+	const onSearchBarChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+		if (e.target.value.trim().length > 0) {
+			setRawQuery(e.target.value.trim())
+		} else {
+			setRawQuery('')
+		}
+	}, [])
+
+	useEffect(() => {
+		setIsTyping(true)
+		const timeoutId = setTimeout(() => {
+			setQuery(rawQuery)
+			setIsTyping(false)
+		}, 300)
+
+		return () => clearTimeout(timeoutId)
+	}, [rawQuery, setQuery, setIsTyping])
+
+	return (
+		<VStack alignItems="left" ml={sideMargin} mr={sideMargin}>
+			<InputGroup>
+				<InputLeftAddon>
+					<SearchIcon />
+				</InputLeftAddon>
+				<Input
+					id="report-search-bar"
+					placeholder="Search tags by name"
+					minWidth="75vw"
+					onChange={onSearchBarChange}
+				/>
+				{isTyping && (
+					<InputRightElement>
+						<Spinner />
+					</InputRightElement>
+				)}
+			</InputGroup>
+			{!!idsError && (
+				<ErrorAlert
+					info={{ label: 'An error occurred while retrieving the reports', reason: idsError }}
+					w="50%"
+				/>
+			)}
+			{!idsError && !!tagIds && tagIds.length === 0 && (
+				<Center>
+					<Alert status="warning" w="50%">
+						<AlertIcon />
+						There are no tags matching your search
+					</Alert>
+				</Center>
+			)}
+			{!!tagsError && (
+				<ErrorAlert
+					info={{ label: 'An error occurred while retrieving the tags', reason: tagsError }}
+					w="50%"
+				/>
+			)}
+			{(idsLoading || tagsLoading) && <StackedSkeleton quantity={5} height="3em" />}
+			<SimpleGrid columns={size?.cards ?? 3} spacing={2}>
+				{!!tags &&
+					tags.length > 0 &&
+					!!tagIds &&
+					tagIds.length > 0 &&
+					tags.map(it => <TagCard key={it._id} tag={it} />)}
+			</SimpleGrid>
+		</VStack>
+	)
+}

--- a/src/pages/user/SearchUsersPage.tsx
+++ b/src/pages/user/SearchUsersPage.tsx
@@ -1,0 +1,125 @@
+import { useAppDispatch } from '../../hooks/redux'
+import React, { useCallback, useEffect, useState } from 'react'
+import { setPageTitle } from '../../store/ui/ui-slice'
+import { useIsMobileLayout } from '../../hooks/responsive-size'
+import {
+	Alert,
+	AlertIcon,
+	Center,
+	Input,
+	InputGroup,
+	InputLeftAddon,
+	InputRightElement,
+	SimpleGrid,
+	Spinner,
+	useBreakpointValue,
+	VStack,
+} from '@chakra-ui/react'
+import { ErrorAlert } from '../../components/errors/ErrorAlert'
+import { StackedSkeleton } from '../../components/ui/StackedSkeleton'
+import { SearchIcon } from '@chakra-ui/icons'
+import { getEntitiesInPage } from '../../utils/array-utils'
+import { PageControls } from '../../components/ui/PageControls'
+import { useGetUsersByUsernameEmailNameQuery } from '../../services/user'
+import { UserCard } from '../../components/models/UserCard'
+import { Size } from '../../components/forms/controls/TagInput'
+
+const cardsForSize: Record<Size, { cards: number }> = {
+	xl: { cards: 4 },
+	lg: { cards: 3 },
+	md: { cards: 2 },
+	sm: { cards: 1 },
+	base: { cards: 1 },
+}
+
+export const SearchUsersPage = () => {
+	const isMobile = useIsMobileLayout()
+	const size = useBreakpointValue<{ cards: number }>(cardsForSize, {
+		fallback: 'md',
+	})
+	const dispatch = useAppDispatch()
+	useEffect(() => {
+		dispatch(setPageTitle('Search Users'))
+	}, [dispatch])
+
+	const pageSize = 40
+	const sideMargin = isMobile ? '0.5em' : '2em'
+
+	const [currentPage, setCurrentPage] = useState<number>(0)
+	const [isTyping, setIsTyping] = useState<boolean>(false)
+	const [rawQuery, setRawQuery] = useState<string>('')
+	const [query, setQuery] = useState<string>('')
+
+	const {
+		data: users,
+		error: usersError,
+		isLoading: usersLoading,
+	} = useGetUsersByUsernameEmailNameQuery({ query, onlyActive: false })
+	const usersInPage = getEntitiesInPage(users, currentPage, pageSize)
+
+	const onSearchBarChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+		if (e.target.value.trim().length > 0) {
+			setRawQuery(e.target.value.trim())
+		} else {
+			setRawQuery('')
+		}
+	}, [])
+
+	useEffect(() => {
+		setIsTyping(true)
+		const timeoutId = setTimeout(() => {
+			setCurrentPage(0)
+			setQuery(rawQuery)
+			setIsTyping(false)
+		}, 300)
+
+		return () => clearTimeout(timeoutId)
+	}, [rawQuery, setQuery, setIsTyping])
+
+	return (
+		<VStack alignItems="left" ml={sideMargin} mr={sideMargin}>
+			<InputGroup>
+				<InputLeftAddon>
+					<SearchIcon />
+				</InputLeftAddon>
+				<Input
+					id="user-search-bar"
+					placeholder="Search users by username, email, name, or surname"
+					minWidth="75vw"
+					onChange={onSearchBarChange}
+				/>
+				{isTyping && (
+					<InputRightElement>
+						<Spinner />
+					</InputRightElement>
+				)}
+			</InputGroup>
+			{!!usersError && (
+				<ErrorAlert
+					info={{ label: 'An error occurred while retrieving the users', reason: usersError }}
+					w="50%"
+				/>
+			)}
+			{!usersError && !!users && users.length === 0 && (
+				<Center>
+					<Alert status="warning" w="50%">
+						<AlertIcon />
+						There are no users matching your search
+					</Alert>
+				</Center>
+			)}
+			{usersLoading && <StackedSkeleton quantity={5} height="3em" />}
+			<SimpleGrid columns={size?.cards ?? 3} spacing={2}>
+				{usersInPage.length > 0 && usersInPage.map(it => <UserCard key={it._id} user={it} />)}
+			</SimpleGrid>
+			<Center>
+				<PageControls
+					hasNext={usersInPage.length >= pageSize}
+					currentPage={currentPage + 1}
+					increasePage={() => setCurrentPage(currentPage + 1)}
+					decreasePage={() => setCurrentPage(currentPage - 1)}
+				/>
+			</Center>
+		</VStack>
+	)
+}

--- a/src/pages/user/UpdateUserPage.tsx
+++ b/src/pages/user/UpdateUserPage.tsx
@@ -10,7 +10,7 @@ import { UpdateUserForm } from '../../components/forms/UpdateUserForm'
 export const UpdateUserPage = () => {
 	const dispatch = useAppDispatch()
 	useEffect(() => {
-		dispatch(setPageTitle('Update User'))
+		dispatch(setPageTitle('Update Your User Details'))
 	}, [dispatch])
 
 	const { data, error, isLoading } = useGetCurrentUserQuery(undefined)

--- a/src/pages/user/UpdateUserPage.tsx
+++ b/src/pages/user/UpdateUserPage.tsx
@@ -1,0 +1,25 @@
+import { useAppDispatch } from '../../hooks/redux'
+import { useEffect } from 'react'
+import { setPageTitle } from '../../store/ui/ui-slice'
+import { useGetCurrentUserQuery } from '../../services/user'
+import { VStack } from '@chakra-ui/react'
+import { generateSkeletons } from '../../components/ui/StackedSkeleton'
+import { ErrorAlert } from '../../components/errors/ErrorAlert'
+import { UpdateUserForm } from '../../components/forms/UpdateUserForm'
+
+export const UpdateUserPage = () => {
+	const dispatch = useAppDispatch()
+	useEffect(() => {
+		dispatch(setPageTitle('Update User'))
+	}, [dispatch])
+
+	const { data, error, isLoading } = useGetCurrentUserQuery(undefined)
+
+	return (
+		<>
+			{isLoading && <VStack>{generateSkeletons({ quantity: 3, minWidth: '90vw', height: '5vh' })}</VStack>}
+			{!!error && <ErrorAlert info={{ label: 'An error occurred while retrieving the user', reason: error }} />}
+			{!!data && <UpdateUserForm user={data} />}
+		</>
+	)
+}

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -2,8 +2,8 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import { JwtResponse } from '../models/auth/JwtResponse'
 import { LoginData } from '../models/auth/loginData'
 
-export const authAPI = createApi({
-	reducerPath: 'authAPI',
+export const authApi = createApi({
+	reducerPath: 'authApi',
 	baseQuery: fetchBaseQuery({
 		baseUrl: `${process.env.REACT_APP_APIURL}`,
 		prepareHeaders: headers => {
@@ -21,4 +21,4 @@ export const authAPI = createApi({
 	}),
 })
 
-export const { useLoginMutation } = authAPI
+export const { useLoginMutation } = authApi

--- a/src/services/box.ts
+++ b/src/services/box.ts
@@ -43,6 +43,21 @@ export const boxApi = createApi({
 			query: (materialId: string) => `/withMaterial/${encodeURIComponent(materialId)}`,
 			providesTags: (boxes, _, materialId) => boxTagWithMaterialProvider(boxes, materialId),
 		}),
+		deleteBoxesWithMaterial: builder.mutation<Box[], string>({
+			query: materialId => ({
+				url: `/withMaterial/${encodeURIComponent(materialId)}`,
+				method: 'DELETE',
+			}),
+			invalidatesTags: (deletedBoxes, _, materialId) => {
+				if (!!deletedBoxes) {
+					const tagsByMaterial = boxTagWithMaterialProvider(deletedBoxes, materialId)
+					const tagsByShelf = deletedBoxes.flatMap(it => boxTagOnShelfProvider([it], it.position))
+					return tagsByMaterial.concat(tagsByShelf)
+				} else {
+					return []
+				}
+			},
+		}),
 		deleteBox: builder.mutation<string, Box>({
 			query: box => ({
 				url: `/${box._id}`,
@@ -74,6 +89,7 @@ export const boxApi = createApi({
 export const {
 	useCreateBoxMutation,
 	useDeleteBoxMutation,
+	useDeleteBoxesWithMaterialMutation,
 	useGetBoxByPositionQuery,
 	useGetBoxWithMaterialQuery,
 	useModifyBoxMutation,

--- a/src/services/box.ts
+++ b/src/services/box.ts
@@ -43,6 +43,10 @@ export const boxApi = createApi({
 			query: (materialId: string) => `/withMaterial/${encodeURIComponent(materialId)}`,
 			providesTags: (boxes, _, materialId) => boxTagWithMaterialProvider(boxes, materialId),
 		}),
+		getUnitsWithMaterial: builder.query<number, string>({
+			query: (materialId: string) => `units/withMaterial/${encodeURIComponent(materialId)}`,
+			providesTags: (_, __, materialId) => boxTagWithMaterialProvider(undefined, materialId),
+		}),
 		deleteBoxesWithMaterial: builder.mutation<Box[], string>({
 			query: materialId => ({
 				url: `/withMaterial/${encodeURIComponent(materialId)}`,
@@ -92,6 +96,7 @@ export const {
 	useDeleteBoxesWithMaterialMutation,
 	useGetBoxByPositionQuery,
 	useGetBoxWithMaterialQuery,
+	useGetUnitsWithMaterialQuery,
 	useModifyBoxMutation,
 	useUpdateQuantityMutation,
 } = boxApi

--- a/src/services/material.ts
+++ b/src/services/material.ts
@@ -59,6 +59,10 @@ export const materialApi = createApi({
 			query: ({ query, limit }) => `/byFuzzyName/${encodeURIComponent(query)}${!!limit ? `?limit=${limit}` : ''}`,
 			providesTags: materialTagProvider,
 		}),
+		getMaterialsByRefCode: builder.query<Material[], string>({
+			query: refCode => `/byRefCode/${encodeURIComponent(refCode)}`,
+			providesTags: materials => materialTagProvider(materials),
+		}),
 		searchIdsByNameBrandCode: builder.query<string[], { query: string; tags: Tag[] | null }>({
 			query: ({ query, tags }) => ({
 				url: `/idsByNameBrandCode?query=${encodeURIComponent(query)}`,
@@ -106,6 +110,7 @@ export const {
 	useDeleteMaterialMutation,
 	useGetLastCreatedQuery,
 	useGetMaterialsByIdsQuery,
+	useGetMaterialsByRefCodeQuery,
 	useGetMaterialQuery,
 	useFilterMaterialsQuery,
 	useFindMaterialsByFuzzyNameQuery,

--- a/src/services/profilePicture.ts
+++ b/src/services/profilePicture.ts
@@ -1,0 +1,66 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import { AuthState } from '../store/auth/auth-slice'
+import { attachmentTagProvider, AttachmentTagType } from './tags/attachment'
+import { ProfilePicture } from '../models/ProfilePicture'
+import { FetchBaseQueryError } from '@reduxjs/toolkit/query'
+
+export const profilePictureApi = createApi({
+	reducerPath: 'attachment',
+	baseQuery: fetchBaseQuery({
+		baseUrl: `${process.env.REACT_APP_APIURL}/profilePicture`,
+		prepareHeaders: (headers, api) => {
+			const {
+				auth: { jwt },
+			} = api.getState() as { auth: AuthState }
+			headers.set('Authorization', `Bearer ${jwt}`)
+		},
+	}),
+	tagTypes: [AttachmentTagType],
+	endpoints: builder => ({
+		getProfilePicture: builder.query<ProfilePicture | null, string>({
+			queryFn: async (pictureId, queryApi, extraOptions, baseQuery) => {
+				const result = await baseQuery(`/${encodeURIComponent(pictureId)}`)
+				if (!!result.error && result.error.status === 404) {
+					return { data: null }
+				} else if (!!result.error) {
+					return {
+						error: {
+							status: result.error?.status,
+							data: 'An error occurred',
+						} as FetchBaseQueryError,
+					}
+				} else {
+					return { data: result.data as ProfilePicture }
+				}
+			},
+			providesTags: picture => (!!picture ? attachmentTagProvider([picture]) : []),
+		}),
+		createProfilePicture: builder.mutation<string, File>({
+			query: data => {
+				const bodyFormData = new FormData()
+				bodyFormData.append('file', data)
+				return {
+					url: '',
+					method: 'POST',
+					body: bodyFormData,
+				}
+			},
+			invalidatesTags: pictureId => (!!pictureId ? [{ type: AttachmentTagType, id: pictureId }] : []),
+		}),
+		modifyProfilePicture: builder.mutation<void, { picture: File; attachmentId: string }>({
+			query: ({ picture, attachmentId }) => {
+				const bodyFormData = new FormData()
+				bodyFormData.append('file', picture)
+				return {
+					url: `/${encodeURIComponent(attachmentId)}`,
+					method: 'PUT',
+					body: bodyFormData,
+				}
+			},
+			invalidatesTags: (_, __, { attachmentId }) => [{ type: AttachmentTagType, id: attachmentId }],
+		}),
+	}),
+})
+
+export const { useCreateProfilePictureMutation, useGetProfilePictureQuery, useModifyProfilePictureMutation } =
+	profilePictureApi

--- a/src/services/profilePicture.ts
+++ b/src/services/profilePicture.ts
@@ -18,7 +18,7 @@ export const profilePictureApi = createApi({
 	tagTypes: [AttachmentTagType],
 	endpoints: builder => ({
 		getProfilePicture: builder.query<ProfilePicture | null, string>({
-			queryFn: async (pictureId, queryApi, extraOptions, baseQuery) => {
+			queryFn: async (pictureId, _, __, baseQuery) => {
 				const result = await baseQuery(`/${encodeURIComponent(pictureId)}`)
 				if (!!result.error && result.error.status === 404) {
 					return { data: null }

--- a/src/services/role.ts
+++ b/src/services/role.ts
@@ -1,0 +1,31 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import { AuthState } from '../store/auth/auth-slice'
+import { Role } from '../models/embed/Role'
+import { RoleTagType } from './tags/role'
+
+export const roleApi = createApi({
+	reducerPath: 'roleApi',
+	baseQuery: fetchBaseQuery({
+		baseUrl: `${process.env.REACT_APP_APIURL}/role`,
+		prepareHeaders: (headers, api) => {
+			const {
+				auth: { jwt },
+			} = api.getState() as { auth: AuthState }
+			headers.set('Authorization', `Bearer ${jwt}`)
+			headers.set('content-type', 'application/json')
+		},
+	}),
+	tagTypes: [RoleTagType],
+	endpoints: builder => ({
+		getRoles: builder.query<Role[], void>({
+			query: () => '',
+			providesTags: roles => (!!roles ? roles.map(it => ({ type: RoleTagType, id: it._id })) : []),
+		}),
+		getRole: builder.query<Role, string>({
+			query: (roleId: string) => `/${encodeURIComponent(roleId)}`,
+			providesTags: role => (!!role ? [{ type: RoleTagType, id: role._id }] : []),
+		}),
+	}),
+})
+
+export const { useGetRoleQuery, useGetRolesQuery } = roleApi

--- a/src/services/tag.ts
+++ b/src/services/tag.ts
@@ -19,7 +19,7 @@ export const metaTagApi = createApi({
 	endpoints: builder => ({
 		getTags: builder.query<Tag[], void>({
 			query: () => '',
-			providesTags: [AllTags],
+			providesTags: metaTagTagProvider,
 		}),
 		getTagsByIds: builder.query<Tag[], string[]>({
 			query: ids => ({
@@ -41,7 +41,42 @@ export const metaTagApi = createApi({
 			}),
 			invalidatesTags: [AllTags],
 		}),
+		deleteTag: builder.mutation<void, string>({
+			query: tagId => ({
+				url: `/${tagId}`,
+				method: 'DELETE',
+			}),
+			invalidatesTags: (_, __, id) => [{ type: TagTagType, id: id }],
+		}),
+		searchTagIdsByName: builder.query<string[], string>({
+			query: query => ({
+				url: `/idsByName?query=${encodeURIComponent(query)}`,
+			}),
+			providesTags: ids =>
+				!!ids
+					? [
+							...ids.map(it => ({ type: TagTagType, id: it } as { type: typeof TagTagType; id: string })),
+							AllTags,
+					  ]
+					: [],
+		}),
+		modifyTag: builder.mutation<void, Tag>({
+			query: data => ({
+				url: '',
+				method: 'PUT',
+				body: JSON.stringify(data),
+			}),
+			invalidatesTags: (_, __, tag) => (!!tag ? [{ type: TagTagType, id: tag._id }] : []),
+		}),
 	}),
 })
 
-export const { useCreateTagMutation, useGetTagsByIdsQuery, useGetTagQuery, useGetTagsQuery } = metaTagApi
+export const {
+	useCreateTagMutation,
+	useDeleteTagMutation,
+	useGetTagsByIdsQuery,
+	useGetTagQuery,
+	useGetTagsQuery,
+	useModifyTagMutation,
+	useSearchTagIdsByNameQuery,
+} = metaTagApi

--- a/src/services/tags/attachment.ts
+++ b/src/services/tags/attachment.ts
@@ -1,0 +1,11 @@
+import { Attachment } from '../../models/Attachment'
+
+export type AttachmentTag = { type: typeof AttachmentTagType; id: string }
+export const AttachmentTagType = 'Attachment'
+
+export const attachmentTagProvider: (attachments: Attachment[] | undefined) => AttachmentTag[] = attachments =>
+	!!attachments
+		? attachments.map(attachment => {
+				return { type: AttachmentTagType, id: attachment._id }
+		  })
+		: []

--- a/src/services/tags/role.ts
+++ b/src/services/tags/role.ts
@@ -1,0 +1,2 @@
+export type RoleTag = { type: typeof RoleTagType; id: string }
+export const RoleTagType = 'Role'

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -3,6 +3,7 @@ import { AuthState } from '../store/auth/auth-slice'
 import { UserTagType } from './tags/user'
 import { User } from '../models/User'
 import { PasswordDto } from '../models/dto/PasswordDto'
+import { UserStatus } from '../models/embed/UserStatus'
 
 export const userApi = createApi({
 	reducerPath: 'userApi',
@@ -67,8 +68,9 @@ export const userApi = createApi({
 			}),
 			invalidatesTags: (_, __, { userId }) => [{ type: UserTagType, id: userId }],
 		}),
-		getUsersByUsernameEmailName: builder.query<User[], string>({
-			query: query => `/byUsernameEmailName?query=${encodeURIComponent(query)}`,
+		getUsersByUsernameEmailName: builder.query<User[], { query: string; onlyActive: boolean }>({
+			query: ({ query, onlyActive }) =>
+				`/byUsernameEmailName?query=${encodeURIComponent(query)}&onlyActive=${onlyActive}`,
 			providesTags: users => (!!users ? users.map(user => ({ type: UserTagType, id: user._id })) : []),
 		}),
 		getUsersByIds: builder.query<User[], string[]>({
@@ -79,11 +81,26 @@ export const userApi = createApi({
 			}),
 			providesTags: users => (!!users ? users.map(user => ({ type: UserTagType, id: user._id })) : []),
 		}),
+		deleteUser: builder.mutation<void, string>({
+			query: userId => ({
+				url: `/${encodeURIComponent(userId)}`,
+				method: 'DELETE',
+			}),
+			invalidatesTags: (_, __, userId) => [{ type: UserTagType, id: userId }],
+		}),
+		setUserStatus: builder.mutation<void, { userId: string; status: UserStatus }>({
+			query: ({ userId, status }) => ({
+				url: `/${encodeURIComponent(userId)}/status/${encodeURIComponent(status)}`,
+				method: 'PUT',
+			}),
+			invalidatesTags: (_, __, { userId }) => [{ type: UserTagType, id: userId }],
+		}),
 	}),
 })
 
 export const {
 	useChangePasswordMutation,
+	useDeleteUserMutation,
 	useGetCurrentUserQuery,
 	useGetUserByIdQuery,
 	useGetUsersByIdsQuery,
@@ -93,4 +110,5 @@ export const {
 	useLazyGetUserByUsernameQuery,
 	useModifyUserMutation,
 	useModifyUserRoleMutation,
+	useSetUserStatusMutation,
 } = userApi

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,7 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { authReducer } from './auth/auth-slice'
 import { authListenerMiddleware } from './auth/auth-middleware'
-import { authAPI } from '../services/auth'
+import { authApi } from '../services/auth'
 import { storageRoomApi } from '../services/storageRoom'
 import { metaTagApi } from '../services/tag'
 import { boxDefinitionApi } from '../services/boxDefinition'
@@ -12,13 +12,15 @@ import { processApi } from '../services/process'
 import { UIReducer } from './ui/ui-slice'
 import { alertApi } from '../services/alert'
 import { reportApi } from '../services/report'
+import { profilePictureApi } from '../services/profilePicture'
 
 export const store = configureStore({
 	reducer: {
 		auth: authReducer,
 		ui: UIReducer,
 		[alertApi.reducerPath]: alertApi.reducer,
-		[authAPI.reducerPath]: authAPI.reducer,
+		[profilePictureApi.reducerPath]: profilePictureApi.reducer,
+		[authApi.reducerPath]: authApi.reducer,
 		[boxApi.reducerPath]: boxApi.reducer,
 		[boxDefinitionApi.reducerPath]: boxDefinitionApi.reducer,
 		[materialApi.reducerPath]: materialApi.reducer,
@@ -32,7 +34,8 @@ export const store = configureStore({
 		getDefaultMiddleware()
 			.prepend(authListenerMiddleware.middleware)
 			.prepend(alertApi.middleware)
-			.prepend(authAPI.middleware)
+			.prepend(profilePictureApi.middleware)
+			.prepend(authApi.middleware)
 			.prepend(boxApi.middleware)
 			.prepend(boxDefinitionApi.middleware)
 			.prepend(metaTagApi.middleware)

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -13,6 +13,7 @@ import { UIReducer } from './ui/ui-slice'
 import { alertApi } from '../services/alert'
 import { reportApi } from '../services/report'
 import { profilePictureApi } from '../services/profilePicture'
+import { roleApi } from '../services/role'
 
 export const store = configureStore({
 	reducer: {
@@ -27,6 +28,7 @@ export const store = configureStore({
 		[metaTagApi.reducerPath]: metaTagApi.reducer,
 		[processApi.reducerPath]: processApi.reducer,
 		[reportApi.reducerPath]: reportApi.reducer,
+		[roleApi.reducerPath]: roleApi.reducer,
 		[storageRoomApi.reducerPath]: storageRoomApi.reducer,
 		[userApi.reducerPath]: userApi.reducer,
 	},
@@ -42,6 +44,7 @@ export const store = configureStore({
 			.prepend(materialApi.middleware)
 			.prepend(processApi.middleware)
 			.prepend(reportApi.middleware)
+			.prepend(roleApi.middleware)
 			.prepend(storageRoomApi.middleware)
 			.prepend(userApi.middleware),
 })

--- a/src/utils/array-utils.ts
+++ b/src/utils/array-utils.ts
@@ -8,3 +8,7 @@ export function chunkArray<T>(array: T[], size: number): T[][] {
 
 export const getIdsInPage = (ids: string[] | undefined, pageIdx: number, pageSize: number) =>
 	ids?.slice(pageIdx * pageSize, (pageIdx + 1) * pageSize) ?? []
+
+export function getEntitiesInPage<T>(entities: T[] | undefined, pageIdx: number, pageSize: number): T[] {
+	return entities?.slice(pageIdx * pageSize, (pageIdx + 1) * pageSize) ?? []
+}


### PR DESCRIPTION
## New Features
- Added a page to search and modify `Tag`s. Closes #21
- Added a page to modify the current user details and added support for profile pictures. Closes #36 
- Added role selection when inviting a new user.
- Added a page to search and modify existing users.
- When adding a `Material` now the form shows a warning if the provided reference number already exist. Closes #47 
- Alerts and Reports threshold is now by box. Closes #48 

## UX Improvements
- Removed the "fullBox" check mark when selecting a quantity to remove/add of a box. Closes #41 
- The BoxDefinition builder in the add Material form now displays a default containing box. Closes #46 
- The `Material` card displays the quantity remaining for that material. Closes #51 
- Added a menu to handle the options of a card instead of the buttons in the footer, where possible. Closes #49 
- When searching for a `Material`, it will display the matches also when the query is in the middle of the name. Closes #50 

## Bug Fixes
- The quantity selection in the box add form now starts from 0. Closes #39 Closes #42 
- When modifying an `Alert` or a `Report` the modal closes on the success confirmation by the user. Closes #40 
- When a `Material` is deleted, all the `Box`es for that material are deleted as well. Closes #43 
- Avoided to fetch multiple times a missing tag.
- Fixed a bug that showed deleted materials in Alert and Report summary. Closes #44 